### PR TITLE
dynamips.1 manpage

### DIFF
--- a/dynamips.1
+++ b/dynamips.1
@@ -44,31 +44,31 @@ c3640 hardware and vice\-versa.
 .SH OPTIONS
 A summary of options is included below.
 .TP
-.B -H <tcp_port>
+.B \-H <tcp_port>
 Enable hypervisor mode.
 .br
 The hypervisor mode of dynamips allows you to run simultaneously
 many virtual router instances, and to simulate ATM, Ethernet
-or Frame-Relay networks.
+or Frame\(hyRelay networks.
 .br
 You can connect directly to the TCP control port with telnet, or use
 \fBdynagen\fP(1), \fBdynagui\fP(1) that will pass commands transparently. 
 The second method is highly recommended.
 .TP
-.B -l <log_file>
+.B \-l <log_file>
 Set logging file (default is dynamips_log.txt)
 .TP
-.B -j
+.B \-j
 Disable the JIT compiler, very slow
 .TP
-.B --exec-area <size>
+.B \-\-exec\-area <size>
 Set the exec area size (default: 64 Mb)
 .br
 The exec area is a pool of host memory used to store pages translated by
 the JIT (they contain the native code corresponding to MIPS code pages).
 
 .TP
-.B --idle-pc <pc>
+.B \-\-idle\-pc <pc>
 Set the idle PC (default: disabled)
 .br
 The "idle PC" feature allows you to run a router instance without having
@@ -79,9 +79,9 @@ To determine the "idle PC", start normally the emulator with your Cisco IOS
 image, and a totally IOS empty configuration (although not mandatory, this
 will give better results). When the image is fully booted, wait for the
 "Press RETURN to get started!" message prompt, but do not press Enter key.
-Wait about 5 seconds, then press "Ctrl-] + i". Some statistics will be
+Wait about 5 seconds, then press "Ctrl\(hy] + i". Some statistics will be
 gathered during 10 seconds. At the end, the emulator will display a list of
-possible values to pass to the "\-\-idle-pc" option. You may have to try some
+possible values to pass to the "\-\-idle\-pc" option. You may have to try some
 values before finding the good one. To check if the idle PC value is good,
 just boot the Cisco IOS image, and check your CPU load when the console
 prompt is available. If it is low, you have found a good value, keep it
@@ -95,37 +95,37 @@ boot a different IOS image without proceeding as described above.
 * Do not run the process while having the "autoconfiguration" prompt.
 
 .TP
-.B --timer-itv <val>
+.B \-\-timer\-itv <val>
 Timer IRQ interval check (default: 1000)
 .TP
-.B -i <instance>
+.B \-i <instance>
 Set instance ID
 .TP
-.B -r <ram_size>
+.B \-r <ram_size>
 Set the virtual RAM size (default: 256 Mb)
 .TP
-.B -o <rom_size>
+.B \-o <rom_size>
 Set the virtual ROM size (default: 4 Mb)
 .TP
-.B -n <nvram_size>
+.B \-n <nvram_size>
 Set the NVRAM size (default: 128 Kb)
 .TP
-.B -c <conf_reg>
+.B \-c <conf_reg>
 Set the configuration register (default: 0x2102)
 .TP
-.B -m <mac_addr>
+.B \-m <mac_addr>
 Set the MAC address of the chassis (default: automatically generated)
 .TP
-.B -C <cfg_file>
+.B \-C <cfg_file>
 Import an IOS configuration file into NVRAM
 .TP
-.B -X
+.B \-X
 Do not use a file to simulate RAM (faster)
 .TP
-.B -R <rom_file>
+.B \-R <rom_file>
 Load an alternate ROM (default: embedded)
 .TP
-.B -k <clock_div>
+.B \-k <clock_div>
 Set the clock divisor (default: 4)
 .br
 Specify the clock divider (integer) based on the host clock.
@@ -133,59 +133,59 @@ Alter the value to match the CISCO clock with the real time.
 The command "show clock" at the IOS' CLI will help you set this value.
 
 .TP
-.B -T <port>
+.B \-T <port>
 Console is on TCP <port>
 .TP
-.B -U <si_desc>
+.B \-U <si_desc>
 Console in on serial interface <si_desc> (default is on the terminal)
 .TP
-.B -A <port>
+.B \-A <port>
 AUX is on TCP <port>
 .TP
-.B -B <si_desc>
+.B \-B <si_desc>
 AUX is on serial interface <si_desc> (default is no AUX port)
 .TP
-.B --disk0 <size>
+.B \-\-disk0 <size>
 Set PCMCIA ATA disk0: size (default: 64 Mb)
 .TP
-.B --disk1 <size>
+.B \-\-disk1 <size>
 Set PCMCIA ATA disk1: size (default: 0 Mb)
 .TP
-.B -a <cfg_file>
+.B \-a <cfg_file>
 Virtual ATM switch configuration file.
 .TP
-.B -f <cfg_file>
-Virtual Frame-Relay switch configuration file.
+.B \-f <cfg_file>
+Virtual Frame\(hyRelay switch configuration file.
 .TP
-.B -E <cfg_file>
+.B \-E <cfg_file>
 Virtual Ethernet switch configuration file.
 .TP
-.B -e
+.B \-e
 Show network device list of the host machine.
 
 .SH OPTIONS specific to the Cisco 7200 series
 .TP
-.B -t <npe_type>
-Select NPE type (default: "npe-200")
+.B \-t <npe_type>
+Select NPE type (default: "npe\(hy200")
 .TP
-.B -M <midplane>
+.B \-M <midplane>
 Select Midplane ("std" or "vxr")
 .TP
-.B -p <pa_desc>
+.B \-p <pa_desc>
 Define a Port Adapter
 .TP
-.B -s <pa_nio>
+.B \-s <pa_nio>
 Bind a Network IO interface to a Port Adapter
 
 .SH OPTIONS specific to the Cisco 3600 series
 .TP
-.B -t <chassis_type>
+.B \-t <chassis_type>
 Select Chassis type (default: "3640")
 .TP
-.B -p <nm_desc>
+.B \-p <nm_desc>
 Define a Network Module
 .TP
-.B -s <nm_nio>
+.B \-s <nm_nio>
 Bind a Network IO interface to a Network Module
 
 .SH Cisco 7200 Port Adapter Description "<pa_desc>"
@@ -199,19 +199,19 @@ the number of the physical slot (starts from 0)
 .B pa_driver
 the name of a Port Adapter driver in:
 .RS
-.IP C7200-IO-FE
+.IP C7200\(hyIO\(hyFE
 (FastEthernet, slot 0 only)
-.IP PA-FE-TX
+.IP PA\(hyFE\(hyTX
 (FastEthernet, slots 1 to 6)
-.IP PA-4E
+.IP PA\(hy4E
 (Ethernet, 4 ports)
-.IP PA-8E
+.IP PA\(hy8E
 (Ethernet, 8 ports)
-.IP PA-4T+
+.IP PA\(hy4T+
 (Serial, 4 ports)
-.IP PA-8T
+.IP PA\(hy8T
 (Serial, 8 ports)
-.IP PA-A1
+.IP PA\(hyA1
 (ATM)
 .SH Cisco 3600 Network Module Description "<nm_desc>"
 .TP
@@ -224,15 +224,15 @@ the number of the physical slot (starts from 0)
 .B nm_driver
 the name of a Network Module driver in:
 .RS
-.IP NM-1E
+.IP NM\(hy1E
 (Ethernet, 1 port)
-.IP NM-4E
+.IP NM\(hy4E
 (Ethernet, 4 ports)
-.IP NM-1FE-TX
+.IP NM\(hy1FE\(hyTX
 (FastEthernet, 1 port)
-.IP NM-4T
+.IP NM\(hy4T
 (Serial, 4 ports)
-.IP Leopard-2FE
+.IP Leopard\(hy2FE
 (Cisco 3660 FastEthernet in slot 0, automatically used)
 .SH NIO binding to Port Adapter "<pa_nio>" and Network Modules "<nm_nio>":
 .TP
@@ -254,7 +254,7 @@ Use unix sockets for local communication.
 <remote_sock> is the file used by the other interface.
 (ex. "/tmp/local:/tmp/remote")
 .IP vde:<control_sock>:<local_sock>
-For use with UML (User-Mode-Linux) or VDE switches.
+For use with UML (User\(hyMode\(hyLinux) or VDE switches.
 VDE stands for "Virtual Distributed Ethernet".
 Please refer to : http://sourceforge.net/projects/vde/
 .IP tap:<tap_name>
@@ -350,7 +350,7 @@ MTS64 cache statistics
 Write IOS configuration to disk (ios_cfg.txt)
 .TP
 .B j 
-Non-JIT mode statistics
+Non\(hyJIT mode statistics
 .TP
 .B x 
 Experimentations (can crash the box!)
@@ -381,7 +381,7 @@ I2:udp:10004:127.0.0.1:10005
 .PP
 The "I0" instance would be launched with the following parameters:
 .TP
-dynamips ios.bin \-p 1:PA-FE-TX \-s 1:0:udp:10001:127.0.0.1:10000
+dynamips ios.bin \-p 1:PA\-FE\-TX \-s 1:0:udp:10001:127.0.0.1:10000
 
 .SH Virtual Ethernet switch
 The virtual ethernet switch is used to emulate an Ethernet network between
@@ -420,7 +420,7 @@ DOT1Q:E2:1
 .SH Virtual ATM switch
 The virtual ATM switch fabric is used to emulate an ATM backbone between
 emulator instances. The use of this virtual switch is not mandatory, you
-can directly connect emulator instances for point-to-point ATM connections.
+can directly connect emulator instances for point\(hyto\(hypoint ATM connections.
 Please note that only basic VP/VC switching is supported, there is no
 support for ILMI/QSAAL/\|.\|.\|. or other specific ATM protocols.
 .br
@@ -478,7 +478,7 @@ IOS Configuration:
 ip cef
 ip vrf test
  rd 1:1
- route-target both 1:1
+ route\-target both 1:1
 int a1/0
  no shut
 int a1/0.2 p
@@ -493,13 +493,13 @@ interface a2/0.2 p
 !
 .fi
 
-.SH Virtual Frame-Relay switch
-The virtual Frame-Relay switch fabric is used to emulate a Frame-Relay
+.SH Virtual Frame\(hyRelay switch
+The virtual Frame\(hyRelay switch fabric is used to emulate a Frame\(hyRelay
 backbone between emulator instances. The use of this virtual switch is not
 mandatory, you can directly connect emulator instances with appropriate IOS
 configuration.
 .br
-Any emulator instance can act as a virtual Frame-Relay switch.
+Any emulator instance can act as a virtual Frame\(hyRelay switch.
 There is only a basic implementation of the LMI protocol (ANSI Annex D), which
 is probably not conforming but works with Cisco IOS. Fortunately, Cisco IOS
 is able to detect automatically the LMI protocol.
@@ -526,11 +526,11 @@ for interface definition is similar to Port Adapters:
 .br
 In the example above, the switch is configured to switch packets
 received on interface S0 with DLCI 200 to interface S1 with DLCI 100,
-and vice-versa.
+and vice\(hyversa.
 
 .SH BUGS
 .TP
-The "npe-g1" Port Adapter is not working.
+The "npe\(hyg1" Port Adapter is not working.
 .TP
 PCMCIA card emulation is not supported yet with Cisco 3600.
 .SH REPORTING BUGS

--- a/hypervisor_mode.7
+++ b/hypervisor_mode.7
@@ -2,9 +2,9 @@
 .SH NAME
 hypervisor_mode \- allows you to run simultaneously
 many virtual router instances, and to simulate ATM, Ethernet
-or Frame-Relay networks.
+or Frame\(hyRelay networks.
 .SH SYNOPSIS
-.B dynamips -H
+.B dynamips \-H
 \fItcp_port\fP
 
 .SH DESCRIPTION
@@ -41,7 +41,7 @@ NIO bridges (shared media)
 ATM switches
 .TP
 .B frsw      
-Frame-Relay switches
+Frame\(hyRelay switches
 .TP
 .B ethsw     
 Ethernet switches
@@ -160,8 +160,8 @@ Start the instance.  At least the IOS image must be set.
 Stop the instance. The settings are kept.
 .TP
 .B c7200 set_npe <instance_name> <npe_name>
-Set the NPE model.  For example: npe-100, npe-400, ... The default is
-"npe-200".
+Set the NPE model.  For example: npe\(hy100, npe\(hy400, ... The default is
+"npe\(hy200".
 .TP
 .B c7200 set_midplane <instance_name> <midplane_name>
 Set the midplane model, it can be either "std" or "vxr". The default is "vxr".
@@ -173,7 +173,7 @@ automatically generated with this pattern : ca<instance_id>.<process_pid>.0000
 .TP
 .B c7200 add_pa_binding <instance_name> <slot> <pa_type>
 Add a Port Adapter binding for the specified slot.  For example: "c7200
-add_pa_binding R1 1 PA-A1" adds a PA-A1 card into slot 1.
+add_pa_binding R1 1 PA\(hyA1" adds a PA\(hyA1 card into slot 1.
 .TP
 .B c7200 remove_pa_binding <instance_name> <slot>
 Remove a Port Adapter binding (if it exists) for the specified slot.
@@ -183,7 +183,7 @@ Display all PA bindings for the router instance.
 .TP
 .B c7200 add_nio_binding <instance_name> <slot> <port> <nio_name>
 Add a NIO binding for the interface designated by "slot/port".  For example:
-"c7200 add_nio_binding R1 1 0 nio1" (with PA-A1 bound to slot 1) binds the NIO
+"c7200 add_nio_binding R1 1 0 nio1" (with PA\(hyA1 bound to slot 1) binds the NIO
 called "nio1" to the interface ATM1/0.
 .TP
 .B c7200 remove_nio_binding <instance_name> <slot> <port>
@@ -241,7 +241,7 @@ automatically generated with this pattern : cc<instance_id>.<process_pid>.0000
 .TP
 .B c3600 add_nm_binding <instance_name> <slot> <pa_type>
 Add a Network Module binding for the specified slot.  For example: "c3600
-add_nm_binding R1 1 NM-1FE-TX" adds a NM-1FE-TX card into slot 1.
+add_nm_binding R1 1 NM\(hy1FE\(hyTX" adds a NM\(hy1FE\(hyTX card into slot 1.
 .TP
 .B c3600 remove_pa_binding <instance_name> <slot>
 Remove a Network Module binding (if it exists) for the specified slot.
@@ -251,7 +251,7 @@ Display all NM bindings for the router instance.
 .TP
 .B c3600 add_nio_binding <instance_name> <slot> <port> <nio_name>
 Add a NIO binding for the interface designated by "slot/port".  For example:
-"c3600 add_nio_binding R1 1 0 nio1" (with NM-1FE-TX bound to slot 1) binds the
+"c3600 add_nio_binding R1 1 0 nio1" (with NM\(hy1FE\(hyTX bound to slot 1) binds the
 NIO called "nio1" to the interface FastEthernet1/0.
 .TP
 .B c3600 remove_nio_binding <instance_name> <slot> <port>
@@ -286,7 +286,7 @@ Create an UNIX NIO with the specified parameters.
 .TP
 .B nio create_vde <nio_name> <control_file> <local_file>
 Create a VDE NIO with the specified parameters. VDE stands for "Virtual
-Distributed Ethernet" and is compatible with UML (User-Mode-Linux) switch.
+Distributed Ethernet" and is compatible with UML (User\(hyMode\(hyLinux) switch.
 .TP
 .B nio create_tap <nio_name> <tap_device>
 Create a TAP NIO. TAP devices are supported only on Linux and FreeBSD and
@@ -387,17 +387,17 @@ Create a new Virtual Channel connection (unidirectional).
 Delete a Virtual Channel connection (unidirectional).
 .RE
 .TP
-.B Virtual Frame-Relay switch ("frsw")
+.B Virtual Frame\(hyRelay switch ("frsw")
 .RS
 .TP
 .B frsw list
-List all Frame-Relay switches.
+List all Frame\(hyRelay switches.
 .TP
 .B frsw create <switch_name>
-Create a new Frame-Relay switch.
+Create a new Frame\(hyRelay switch.
 .TP
 .B frsw delete <switch_name>
-Delete the specified Frame-Relay switch.
+Delete the specified Frame\(hyRelay switch.
 frsw create_vc <switch_name> <input_nio> <input_dlci> <output_nio> <output_dlci>
 Create a new Virtual Circuit connection (unidirectional).
 .TP


### PR DESCRIPTION
Fixed the following Lintian info-error as per http://lists.debian.org/debian-devel/2003/03/msg01481.html

I: dynamips-community: hyphen-used-as-minus-sign usr/share/man/man1/dynamips.1.gz
