### PR TITLE
Makefile modifications to improve build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,13 @@
 #   - Use "amd64" for a build on x86_64 (64-bits)
 #   - Use "ppc32" for a build on powerpc (32-bits)
 #   - Use "nojit" for unsupported architectures.
+ifeq ($(shell arch),x86_64)
+export DYNAMIPS_ARCH?=amd64
+else
+ifeq ($(shell arch),i686)
 export DYNAMIPS_ARCH?=x86
-
-# Do you want to use lib (for 32 bit compiling) or lib64
-export DYNAMIPS_LIB?=lib
-#export DYNAMIPS_LIB?=lib64
+endif
+endif
 
 # For MAC x64 you can compile the "unstable" version, which should work
 # fine, or use stable if you prefer.

--- a/stable/Makefile
+++ b/stable/Makefile
@@ -10,10 +10,6 @@ ifeq ($(DYNAMIPS_ARCH),ppc32)
 DYNAMIPS_ARCH=x86
 endif
 
-# Do you want to use lib (for 32 bit compiling) or lib64
-DYNAMIPS_LIB?=lib
-
-
 # Get include files from the current directory and from the common directory
 INCLUDE+=-I. -I../common
 
@@ -76,7 +72,7 @@ ifeq ($(shell uname), Linux)
 #   PCAP_LIB=-lpcap
    OSNAME=Linux
    CFLAGS+=-I/usr/include -I. $(PTHREAD_CFLAGS)
-   LIBS=-L/usr/lib -L. -ldl -lrt -luuid /usr/$(DYNAMIPS_LIB)/libelf.a $(PTHREAD_LIBS)
+   LIBS=-L/usr/lib -L. -ldl -lrt -luuid -lelf $(PTHREAD_LIBS)
    DESTDIR=/usr
 else
 ifeq ($(shell uname -s), Darwin)

--- a/unstable/Makefile
+++ b/unstable/Makefile
@@ -9,10 +9,6 @@
 #DYNAMIPS_ARCH?=amd64
 DYNAMIPS_ARCH?=amd64
 
-# Do you want to use lib (for 32 bit compiling) or lib64
-#DYNAMIPS_LIB?=lib
-DYNAMIPS_LIB?=lib64
-
 # Get include files from the current directory and from the common directory
 INCLUDE+=-I. -I../common
 
@@ -76,7 +72,7 @@ ifeq ($(shell uname), Linux)
 #   PCAP_LIB=-lpcap
    OSNAME=Linux
    CFLAGS+=-I/usr/include -I. $(PTHREAD_CFLAGS)
-   LIBS=-L/usr/lib -L. -ldl -lrt -luuid /usr/$(DYNAMIPS_LIB)/libelf.a $(PTHREAD_LIBS)
+   LIBS=-L/usr/lib -L. -ldl -lrt -luuid -lelf $(PTHREAD_LIBS)
    DESTDIR=/usr
 else
 ifeq ($(shell uname -s), Darwin)


### PR DESCRIPTION
Whilst working on the debian packaging for dynamips, I have come across a number of modifications to the Makefiles that I believe may help streamline the build process.
1. In the top-level Makefile I have added an if routine to determine whether we are running on x86_64 or i386/i686. This is particularly useful with the new Launchpad PPA I am setting up, as the build process is automated from a single source upload. As I can only comment on my own build environment, this may need to be tweaked for others, so I will greatfully accept comments on this.
2. In the process of building the Debian specific packages, I came across the problem of where to find the libraries. Either /usr/lib or /usr/lib/<ARCH>-linux-gnu. The only section using the DYNAMIPS_LIB variable was the linux routine to link to libelf.a  
   I propose replacing the fixed path with -lelf as is used in almost all the other routines (Darwin, FreeBSD, SunOS, Cygwin) in both stable/Makefile and unstable/Makefile.  
   This change then leaves the DYNAMIPS_LIB variable unused and surplus to requirements, so could be removed altogether to prevent confusion

Daniel (claydon_dan)
