### PR TITLE
EthernetSwitch: Allow to choose ethertype for QinQ outer tag.

### DIFF
--- a/common/eth_switch.h
+++ b/common/eth_switch.h
@@ -55,7 +55,7 @@ struct ethsw_table {
    char *name;
    pthread_mutex_t lock;
    int debug;
-   
+
    /* Virtual Ports */
    netio_desc_t *nio[ETHSW_MAX_NIO];
 
@@ -105,7 +105,7 @@ int ethsw_set_access_port(ethsw_table_t *t,char *nio_name,u_int vlan_id);
 int ethsw_set_dot1q_port(ethsw_table_t *t,char *nio_name,u_int native_vlan);
 
 /* Set port as a Q-in-Q port */
-int ethsw_set_qinq_port(ethsw_table_t *t,char *nio_name,u_int outer_vlan);
+int ethsw_set_qinq_port(ethsw_table_t *t,char *nio_name,u_int outer_vlan,m_uint16_t ethertype);
 
 /* Save the configuration of a switch */
 void ethsw_save_config(ethsw_table_t *t,FILE *fd);

--- a/common/hv_ethsw.c
+++ b/common/hv_ethsw.c
@@ -106,7 +106,7 @@ static int cmd_delete(hypervisor_conn_t *conn,int argc,char *argv[])
    return(res);
 }
 
-/* 
+/*
  * Add a NIO to an Ethernet switch.
  *
  * Parameters: <ethsw_name> <nio_name>
@@ -117,7 +117,7 @@ static int cmd_add_nio(hypervisor_conn_t *conn,int argc,char *argv[])
 
    if (!(t = hypervisor_find_object(conn,argv[0],OBJ_TYPE_ETHSW)))
       return(-1);
-   
+
    if (ethsw_add_netio(t,argv[1]) == -1) {
       ethsw_release(argv[0]);
       hypervisor_send_reply(conn,HSC_ERR_BINDING,1,
@@ -131,7 +131,7 @@ static int cmd_add_nio(hypervisor_conn_t *conn,int argc,char *argv[])
    return(0);
 }
 
-/* 
+/*
  * Remove a NIO from an Ethernet switch
  *
  * Parameters: <ethsw_name> <nio_name>
@@ -142,7 +142,7 @@ static int cmd_remove_nio(hypervisor_conn_t *conn,int argc,char *argv[])
 
    if (!(t = hypervisor_find_object(conn,argv[0],OBJ_TYPE_ETHSW)))
       return(-1);
-   
+
    if (ethsw_remove_netio(t,argv[1]) == -1) {
       ethsw_release(argv[0]);
       hypervisor_send_reply(conn,HSC_ERR_BINDING,1,
@@ -156,7 +156,7 @@ static int cmd_remove_nio(hypervisor_conn_t *conn,int argc,char *argv[])
    return(0);
 }
 
-/* 
+/*
  * Set a port as an access port.
  *
  * Parameters: <ethsw_name> <nio> <VLAN>
@@ -167,7 +167,7 @@ static int cmd_set_access_port(hypervisor_conn_t *conn,int argc,char *argv[])
 
    if (!(t = hypervisor_find_object(conn,argv[0],OBJ_TYPE_ETHSW)))
       return(-1);
-   
+
    if (ethsw_set_access_port(t,argv[1],atoi(argv[2])) == -1) {
       ethsw_release(argv[0]);
       hypervisor_send_reply(conn,HSC_ERR_BINDING,1,
@@ -175,12 +175,12 @@ static int cmd_set_access_port(hypervisor_conn_t *conn,int argc,char *argv[])
       return(-1);
    }
 
-   ethsw_release(argv[0]);   
+   ethsw_release(argv[0]);
    hypervisor_send_reply(conn,HSC_INFO_OK,1,"Port settings OK");
    return(0);
 }
 
-/* 
+/*
  * Set a port as a trunk (802.1Q) port.
  *
  * Parameters: <ethsw_name> <nio> <native_VLAN>
@@ -191,7 +191,7 @@ static int cmd_set_dot1q_port(hypervisor_conn_t *conn,int argc,char *argv[])
 
    if (!(t = hypervisor_find_object(conn,argv[0],OBJ_TYPE_ETHSW)))
       return(-1);
-   
+
    if (ethsw_set_dot1q_port(t,argv[1],atoi(argv[2])) == -1) {
       ethsw_release(argv[0]);
       hypervisor_send_reply(conn,HSC_ERR_BINDING,1,
@@ -199,31 +199,35 @@ static int cmd_set_dot1q_port(hypervisor_conn_t *conn,int argc,char *argv[])
       return(-1);
    }
 
-   ethsw_release(argv[0]);   
+   ethsw_release(argv[0]);
    hypervisor_send_reply(conn,HSC_INFO_OK,1,"Port settings OK");
    return(0);
 }
 
-/* 
+/*
  * Set a port as a trunk (QinQ) port.
  *
- * Parameters: <ethsw_name> <nio> <outer_VLAN>
+ * Parameters: <ethsw_name> <nio> <outer_VLAN> <ethertype>
  */
 static int cmd_set_qinq_port(hypervisor_conn_t *conn,int argc,char *argv[])
 {
    ethsw_table_t *t;
+   m_uint16_t ethertype = N_ETH_PROTO_DOT1Q;
 
    if (!(t = hypervisor_find_object(conn,argv[0],OBJ_TYPE_ETHSW)))
       return(-1);
-   
-   if (ethsw_set_qinq_port(t,argv[1],atoi(argv[2])) == -1) {
+
+   if (argc == 4) {
+      sscanf(argv[3], "0x%hx", &ethertype);
+   }
+   if (ethsw_set_qinq_port(t,argv[1],atoi(argv[2]),ethertype) == -1) {
       ethsw_release(argv[0]);
       hypervisor_send_reply(conn,HSC_ERR_BINDING,1,
                             "unable to apply port settings");
       return(-1);
    }
 
-   ethsw_release(argv[0]);   
+   ethsw_release(argv[0]);
    hypervisor_send_reply(conn,HSC_INFO_OK,1,"Port settings OK");
    return(0);
 }
@@ -238,7 +242,7 @@ static int cmd_clear_mac_addr_table(hypervisor_conn_t *conn,
       return(-1);
 
    ethsw_clear_mac_addr_table(t);
-   ethsw_release(argv[0]);   
+   ethsw_release(argv[0]);
    hypervisor_send_reply(conn,HSC_INFO_OK,1,"OK");
    return(0);
 }
@@ -266,12 +270,12 @@ static int cmd_show_mac_addr_table(hypervisor_conn_t *conn,
 
    if (!(t = hypervisor_find_object(conn,argv[0],OBJ_TYPE_ETHSW)))
       return(-1);
-   
+
    ethsw_iterate_mac_addr_table(t,
                                 (ethsw_foreach_entry_t)cmd_show_mac_addr_entry,
                                 conn);
 
-   ethsw_release(argv[0]);   
+   ethsw_release(argv[0]);
    hypervisor_send_reply(conn,HSC_INFO_OK,1,"OK");
    return(0);
 }
@@ -302,7 +306,7 @@ static hypervisor_cmd_t ethsw_cmd_array[] = {
    { "remove_nio", 2, 2, cmd_remove_nio, NULL },
    { "set_access_port", 3, 3, cmd_set_access_port, NULL },
    { "set_dot1q_port", 3, 3, cmd_set_dot1q_port, NULL },
-   { "set_qinq_port", 3, 3, cmd_set_qinq_port, NULL },
+   { "set_qinq_port", 3, 4, cmd_set_qinq_port, NULL },
    { "clear_mac_addr_table", 1, 1, cmd_clear_mac_addr_table, NULL },
    { "show_mac_addr_table", 1, 1, cmd_show_mac_addr_table, NULL },
    { "list", 0, 0, cmd_list, NULL },

--- a/common/net.h
+++ b/common/net.h
@@ -16,7 +16,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 
-#define N_IP_ADDR_LEN   4 
+#define N_IP_ADDR_LEN   4
 #define N_IP_ADDR_BITS  32
 
 #define N_IPV6_ADDR_LEN   16
@@ -113,6 +113,7 @@ typedef struct {
 #define N_ETH_PROTO_DOT1Q    0x8100
 #define N_ETH_PROTO_DOT1Q_2  0x9100
 #define N_ETH_PROTO_DOT1Q_3  0x9200
+#define N_ETH_PROTO_DOT1Q_4  0x88A8
 #define N_ETH_PROTO_MPLS     0x8847
 #define N_ETH_PROTO_MPLS_MC  0x8848
 #define N_ETH_PROTO_LOOP     0x9000

--- a/common/net_io.h
+++ b/common/net_io.h
@@ -178,7 +178,7 @@ struct netio_desc {
    void *dptr;
    char *name;
    int debug;
-   
+
    /* Frame Relay specific information */
    m_uint8_t fr_lmi_seq;
    void *fr_conn_list;
@@ -187,6 +187,7 @@ struct netio_desc {
    u_int vlan_port_type;
    m_uint16_t vlan_id;
    void *vlan_input_vector;
+   m_uint16_t ethertype;
 
    union {
       netio_unix_desc_t nud;
@@ -217,7 +218,7 @@ struct netio_desc {
    u_int bandwidth;
    m_uint64_t bw_cnt[NETIO_BW_SAMPLES];
    m_uint64_t bw_cnt_total;
-   u_int bw_pos;  
+   u_int bw_pos;
    u_int bw_ptask_cnt;
 
    /* Packet filters */


### PR DESCRIPTION
This patch makes possible to chose ethertype for outer tag.
Possible values are: 0x8100 (default), 0x9100, 0x9200, 0x88A8.
Hypervisor command `set_qinq_port` can accept 4th optional argument, that holds ethertype. Also this parameter can be accepted via config file as 4th optional argument.

Related pull requests:
GNS3/gns3-server#297
GNS3/gns3-gui#618