### PR TITLE
Fix tap interface usage on FreeBSD

### DIFF
--- a/common/net_io.c
+++ b/common/net_io.c
@@ -609,9 +609,11 @@ static int netio_tap_open(char *tap_devname)
    return(fd);
 #else
    int i,fd = -1;
+   char tap_fullname[NETIO_DEV_MAXLEN];
    
    if (*tap_devname) {
-      fd = open(tap_devname,O_RDWR);
+      snprintf(tap_fullname,NETIO_DEV_MAXLEN,"/dev/%s",tap_devname);
+      fd = open(tap_fullname,O_RDWR);
    } else {
       for(i=0;i<16;i++) {
          snprintf(tap_devname,NETIO_DEV_MAXLEN,"/dev/tap%d",i);


### PR DESCRIPTION
On other OS than linux, it tried to open("tapX") device that didn't exist: It needs at minimum call open("/dev/tapX"). This fix tap usage on FreeBSD at minimum (tested), but should fix it on other OS too.

Before this patch:
```
# dynamips -P 3725 --idle-pc 0x602467a4 -T 2001 -r 256 -j -s 0:0:netio_tap:tap49 -s 0:1:netio_tap:tap50 c3725-adventerprisek9-mz.124-25d.bin
Cisco Router Simulation Platform (version 0.2.15-amd64/FreeBSD stable)
Copyright (c) 2005-2011 Christophe Fillot.
Build date: Apr 22 2017 05:52:43

Local UUID: e923c150-338f-4d37-b553-4a43e0a50c3f

Idle PC set to 0x602467a4.
Virtual RAM size set to 256 MB.
netio_tap_create: unable to open TAP device tap49 (No such file or directory)
C3725 'default': unable to create NETIO descriptor for slot 0
netio_tap_create: unable to open TAP device tap50 (No such file or directory)
C3725 'default': unable to create NETIO descriptor for slot 0
```
