### PR TITLE
Set nonblocking I/O for UDP sockets

### DIFF
--- a/common/net.c
+++ b/common/net.c
@@ -342,6 +342,10 @@ int udp_connect(int local_port,char *remote_host,int remote_port)
    }
 
    freeaddrinfo(res0);
+
+   if (sck >= 0 && m_fd_set_non_block(sck) < 0)
+      perror("Warning: udp_connect: m_fd_set_non_block");
+
    return(sck);
 }
 #else
@@ -387,7 +391,11 @@ int udp_connect(int local_port,char *remote_host,int remote_port)
    if (connect(sck,(struct sockaddr *)&sin,sizeof(sin)) < 0) {
       perror("udp_connect: connect");
       close(sck);
+      return(-1);
    }
+
+   if (m_fd_set_non_block(sck) < 0)
+      perror("Warning: udp_connect: m_fd_set_non_block");
 
    return(sck);
 }

--- a/common/utils.c
+++ b/common/utils.c
@@ -399,7 +399,7 @@ int m_fd_set_non_block(int fd)
 {
    int flags;
 
-   if ((flags = fcntl(fd,F_GETFL,0)) < 1)
+   if ((flags = fcntl(fd,F_GETFL,0)) < 0)
       return(-1);
 
    return(fcntl(fd,F_SETFL, flags | O_NONBLOCK));


### PR DESCRIPTION
Fixes https://github.com/GNS3/gns3-gui/issues/2177

Only the changes for UDP sockets are included, the other NETIO types including Auto-UDP are unchanged.

Tested with Linux and MacOS, no tests done on Windows. On MacOS I'm unable to create the issue, so I could check only, that the modified dynamips is still working.

Build that way on MacOS 10.11.6 (El Capitan):
```
brew install gcc@4.9 cmake libelf
git clone ...
cd dynamips
mkdir build
cd build
cmake .. -DCMAKE_C_COMPILER=/usr/local/bin/gcc-4.9 -DCMAKE_EXE_LINKER_FLAGS=-static-libgcc
make
strip unstable/dynamips
```

The "-DCMAKE_EXE_LINKER_FLAGS=-static-libgcc" links the gcc-4.9 library statically into the dynamips binary.
