### PR TITLE
Fix SEGV during snprintf and localtime_r

### DIFF
--- a/common/dev_nvram.c
+++ b/common/dev_nvram.c
@@ -49,19 +49,19 @@ static m_uint8_t u8_to_bcd(m_uint8_t val)
 static m_uint64_t get_current_time(cpu_gen_t *cpu)
 {
    m_uint64_t res;
-   struct tm *tmx;
-   time_t ct;
-   
-   time(&ct);
-   tmx = localtime(&ct);
-   
-   res =  u8_to_bcd(tmx->tm_sec)  << 8;
-   res += u8_to_bcd(tmx->tm_min)  << 16;
-   res += u8_to_bcd(tmx->tm_hour) << 24;
-   res += ((m_uint64_t)(u8_to_bcd(tmx->tm_wday))) << 32;
-   res += ((m_uint64_t)(u8_to_bcd(tmx->tm_mday))) << 40;
-   res += ((m_uint64_t)(u8_to_bcd(tmx->tm_mon+1))) << 48;
-   res += ((m_uint64_t)(u8_to_bcd(tmx->tm_year))) << 56;
+   struct tm tmx;
+   struct timespec spec;
+
+   clock_gettime(CLOCK_REALTIME, &spec);
+   gmtime_r(&spec.tv_sec, &tmx);
+
+   res =  u8_to_bcd(tmx.tm_sec)  << 8;
+   res += u8_to_bcd(tmx.tm_min)  << 16;
+   res += u8_to_bcd(tmx.tm_hour) << 24;
+   res += ((m_uint64_t)(u8_to_bcd(tmx.tm_wday))) << 32;
+   res += ((m_uint64_t)(u8_to_bcd(tmx.tm_mday))) << 40;
+   res += ((m_uint64_t)(u8_to_bcd(tmx.tm_mon+1))) << 48;
+   res += ((m_uint64_t)(u8_to_bcd(tmx.tm_year))) << 56;
 
    return(res);
 }

--- a/common/utils.c
+++ b/common/utils.c
@@ -257,19 +257,17 @@ void mem_dump(FILE *f_output,u_char *pkt,u_int len)
 /* Logging function */
 void m_flog(FILE *fd,char *module,char *fmt,va_list ap)
 {
-   struct timeval now;
+   struct timespec spec;
    struct tm tmn;
-   time_t ct;
    char buf[256];
 
    if (fd != NULL) {
-      gettimeofday(&now,0);
-      ct = now.tv_sec;
-      localtime_r(&ct,&tmn);
+      clock_gettime(CLOCK_REALTIME, &spec);
+      gmtime_r(&spec.tv_sec, &tmn);
 
       strftime(buf,sizeof(buf),"%b %d %H:%M:%S",&tmn);
 
-      fprintf(fd,"%s.%03ld %s: ",buf,(long)now.tv_usec/1000,module);
+      fprintf(fd,"%s.%03ld %s: ",buf,(long)spec.tv_nsec/1000000,module);
       vfprintf(fd,fmt,ap);
       fflush(fd);
    }

--- a/stable/cpu.c
+++ b/stable/cpu.c
@@ -123,9 +123,61 @@ void cpu_log(cpu_gen_t *cpu,char *module,char *format,...)
 {
    char buffer[256];
    va_list ap;
+   char *i;
+   char *buf;
+
+   buffer[0] = 'C';
+   buffer[1] = 'P';
+   buffer[2] = 'U';
+
+   switch (cpu->id){
+       case 0:
+           buffer[3] = '0';
+           break;
+       case 1:
+           buffer[3] = '1';
+           break;
+       case 2:
+           buffer[3] = '2';
+           break;
+       case 3:
+           buffer[3] = '3';
+           break;
+       case 4:
+           buffer[3] = '4';
+           break;
+       case 5:
+           buffer[3] = '5';
+           break;
+       case 6:
+           buffer[3] = '6';
+           break;
+       case 7:
+           buffer[3] = '7';
+           break;
+       case 8:
+           buffer[3] = '8';
+           break;
+       case 9:
+           buffer[3] = '9';
+           break;
+       default:
+           buffer[3] = '-';
+           break;
+   }
+
+   buffer[4] = ':';
+   buffer[5] = ' ';
+
+   buf = &buffer[6];
+   for(i = module; *i != '\0'; ++i) {
+       *buf = *i;
+       ++buf;
+   }
+
+   *buf = '\0';
 
    va_start(ap,format);
-   snprintf(buffer,sizeof(buffer),"CPU%u: %s",cpu->id,module);
    vm_flog(cpu->vm,buffer,format,ap);
    va_end(ap);
 }


### PR DESCRIPTION
I found that this works for me.
I have tested this patch with Ubuntu 19.04(gcc 8.3.0).
I found that main problem inside libc. Main reason of this problem is using of JIT and registers of CPU. Some time gcc make some optiomization so registers overlaps in multithread environment so we have SEGV. Picture have some asm code where SEGV occured.  
![image](https://user-images.githubusercontent.com/10596076/61066071-91410b80-a40d-11e9-872a-54f39f9994dc.png)
