### PR TITLE
Fix stack alignment for JIT function call targets

### DIFF
--- a/stable/mips_mts.c
+++ b/stable/mips_mts.c
@@ -142,6 +142,7 @@ static void *MTS_PROTO(lookup)(cpu_mips_t *cpu,m_uint64_t vaddr)
 /* === MIPS Memory Operations ============================================= */
 
 /* LB: Load Byte */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(lb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -153,6 +154,7 @@ fastcall void MTS_PROTO(lb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LBU: Load Byte Unsigned */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(lbu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -164,6 +166,7 @@ fastcall void MTS_PROTO(lbu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LH: Load Half-Word */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(lh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -175,6 +178,7 @@ fastcall void MTS_PROTO(lh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LHU: Load Half-Word Unsigned */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(lhu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -186,6 +190,7 @@ fastcall void MTS_PROTO(lhu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LW: Load Word */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(lw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -197,6 +202,7 @@ fastcall void MTS_PROTO(lw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LWU: Load Word Unsigned */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(lwu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -208,6 +214,7 @@ fastcall void MTS_PROTO(lwu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LD: Load Double-Word */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(ld)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -219,6 +226,7 @@ fastcall void MTS_PROTO(ld)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SB: Store Byte */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(sb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -230,6 +238,7 @@ fastcall void MTS_PROTO(sb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SH: Store Half-Word */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(sh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -241,6 +250,7 @@ fastcall void MTS_PROTO(sh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SW: Store Word */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(sw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -252,6 +262,7 @@ fastcall void MTS_PROTO(sw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SD: Store Double-Word */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(sd)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -263,6 +274,7 @@ fastcall void MTS_PROTO(sd)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LDC1: Load Double-Word To Coprocessor 1 */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(ldc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -274,6 +286,7 @@ fastcall void MTS_PROTO(ldc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LWL: Load Word Left */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(lwl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
@@ -297,6 +310,7 @@ fastcall void MTS_PROTO(lwl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LWR: Load Word Right */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(lwr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
@@ -321,6 +335,7 @@ fastcall void MTS_PROTO(lwr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LDL: Load Double-Word Left */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(ldl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
@@ -343,6 +358,7 @@ fastcall void MTS_PROTO(ldl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LDR: Load Double-Word Right */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(ldr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
@@ -365,6 +381,7 @@ fastcall void MTS_PROTO(ldr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SWL: Store Word Left */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(swl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
@@ -389,6 +406,7 @@ fastcall void MTS_PROTO(swl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SWR: Store Word Right */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(swr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
@@ -413,6 +431,7 @@ fastcall void MTS_PROTO(swr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SDL: Store Double-Word Left */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(sdl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
@@ -437,6 +456,7 @@ fastcall void MTS_PROTO(sdl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SDR: Store Double-Word Right */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(sdr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
@@ -461,6 +481,7 @@ fastcall void MTS_PROTO(sdr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LL: Load Linked */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(ll)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -474,6 +495,7 @@ fastcall void MTS_PROTO(ll)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SC: Store Conditional */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(sc)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -489,6 +511,7 @@ fastcall void MTS_PROTO(sc)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SDC1: Store Double-Word from Coprocessor 1 */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(sdc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -500,6 +523,7 @@ fastcall void MTS_PROTO(sdc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* CACHE: Cache operation */
+__attribute__((force_align_arg_pointer))
 fastcall void MTS_PROTO(cache)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int op)
 {
    mips64_jit_tcb_t *block;

--- a/stable/ppc32_mem.c
+++ b/stable/ppc32_mem.c
@@ -722,6 +722,7 @@ static void ppc405_dump_tlb(cpu_gen_t *cpu)
 /* === PPC Memory Operations ============================================= */
 
 /* LBZ: Load Byte Zero */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_lbz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -733,6 +734,7 @@ fastcall void ppc32_lbz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LHZ: Load Half-Word Zero */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_lhz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -744,6 +746,7 @@ fastcall void ppc32_lhz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LWZ: Load Word Zero */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_lwz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -755,6 +758,7 @@ fastcall void ppc32_lwz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LWBR: Load Word Byte Reverse */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_lwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -766,6 +770,7 @@ fastcall void ppc32_lwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LHA: Load Half-Word Algebraic */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_lha(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -777,6 +782,7 @@ fastcall void ppc32_lha(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STB: Store Byte */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_stb(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -788,6 +794,7 @@ fastcall void ppc32_stb(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STH: Store Half-Word */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_sth(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -799,6 +806,7 @@ fastcall void ppc32_sth(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STW: Store Word */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_stw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -810,6 +818,7 @@ fastcall void ppc32_stw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STWBR: Store Word Byte Reversed */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_stwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -821,6 +830,7 @@ fastcall void ppc32_stwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LSW: Load String Word */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_lsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -832,6 +842,7 @@ fastcall void ppc32_lsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STW: Store String Word */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_stsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -843,6 +854,7 @@ fastcall void ppc32_stsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LFD: Load Floating-Point Double */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_lfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -854,6 +866,7 @@ fastcall void ppc32_lfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STFD: Store Floating-Point Double */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_stfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -865,6 +878,7 @@ fastcall void ppc32_stfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* ICBI: Instruction Cache Block Invalidate */
+__attribute__((force_align_arg_pointer))
 fastcall void ppc32_icbi(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int op)
 {
    ppc32_jit_tcb_t *block;


### PR DESCRIPTION
This change fixes a SIGSEGV error caused by a violation of the X84_64 ABI which demands that the stack pointer is aligned to a 16-byte boundary prior to a CALL. The commit message contains a bit more info.

This probably resolves issue #128.

Another variant of fixing this issue is implemented in https://github.com/DresslerFrank/dynamips/commit/0db6692d11a820e92ee6b7a6b25ad2a751508853