### PR TITLE
Add workflow to perform a weekly coverity scan build.

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,6 +1,7 @@
 name: Coverity Scan
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 4 * * 1'  ## every Monday morning
 

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,0 +1,69 @@
+name: Coverity Scan
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'  ## every Monday morning
+
+env:
+  COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+  COVERITY_SCAN_EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}
+  COVERITY_PROJECT: GNS3/dynamips
+  COV_TOOLS_DIR: ${{ github.workspace }}/cov-analysis-linux64
+  COV_BUILD_DIR: ${{ github.workspace }}/coverity-build
+  COV_RESULTS_DIR: cov-int
+  COV_RESULTS_FILE: analysis-results.tgz
+
+jobs:
+  coverity_scan:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up environment
+        run: |
+          sudo apt-get -yq update
+          sudo apt-get -yq install libelf-dev libpcap0.8-dev
+
+      - name: Download and install Coverity Build Tool
+        run: |
+          wget -q https://scan.coverity.com/download/cxx/linux64 \
+                --post-data "token=${COVERITY_SCAN_TOKEN}&project=${COVERITY_PROJECT}" \
+                -O cov-analysis-linux64.tar.gz
+          mkdir ${COV_TOOLS_DIR}
+          tar xzf cov-analysis-linux64.tar.gz --strip 1 -C ${COV_TOOLS_DIR}
+
+      - name: Prepare CMake build
+        run: |
+          mkdir ${COV_BUILD_DIR}
+          cd ${COV_BUILD_DIR}
+          cmake ${CMAKE_BUILD_OPTIONS} ..
+        env:
+          CMAKE_BUILD_OPTIONS: "-DCMAKE_BUILD_TYPE=Release -DDYNAMIPS_CODE=both"
+
+      - name: Run Coverity Scan Analysis Tool
+        run: |
+          export PATH=${COV_TOOLS_DIR}/bin:$PATH
+          cd ${COV_BUILD_DIR}
+          cov-build --dir ${COV_RESULTS_DIR} make -j 2
+          cov-import-scm --dir ${COV_RESULTS_DIR} --scm git --log ${COV_RESULTS_DIR}/scm-log.txt 2>&1
+
+      - name: Upload Coverity Scan Analysis results
+        run: |
+          cd ${COV_BUILD_DIR}
+          tar czf ${COV_RESULTS_FILE} ${COV_RESULTS_DIR}
+          curl \
+            --form project=${COVERITY_PROJECT} \
+            --form token=${COVERITY_SCAN_TOKEN} \
+            --form email=${COVERITY_SCAN_EMAIL} \
+            --form file=@${COV_RESULTS_FILE} \
+            --form version=${GITHUB_SHA} \
+            --form description="GitHub Action - Coverity Scan" \
+              https://scan.coverity.com/builds?project=${COVERITY_PROJECT}
+
+      - name: Upload scan logs as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: scan-logs
+          path: |
+            ${{ env.COV_BUILD_DIR }}/${{ env.COV_RESULTS_DIR }}/scm-log.txt
+            ${{ env.COV_BUILD_DIR }}/${{ env.COV_RESULTS_DIR }}/build-log.txt


### PR DESCRIPTION
This workflow is based on what ja2-straciatella has.

Additional tasks for the repo owner (not me):
- [ ] add project to Coverity Scan
  go to https://scan.coverity.com/projects and press "Register my GitHub project"
- [ ] Fill in the secrets COVERITY_SCAN_TOKEN and COVERITY_SCAN_EMAIL
  how to add secrets: read https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
  secrets: open project page in Coverity Scan, click Submit Build, read example in section "Automation"
- [ ] add me in the Coverity Scan project

I'm done processing all the old microcode and can make my own.
To play with the microcode I'm gonna have to mess with C code.
So, time to fix stuff...