### PR TITLE
Fix uninitialized field in ppc405_slow_lookup

### DIFF
--- a/stable/ppc32_mem.c
+++ b/stable/ppc32_mem.c
@@ -653,6 +653,7 @@ static mts32_entry_t *ppc405_slow_lookup(cpu_ppc_t *cpu,m_uint32_t vaddr,
    {
       map.vaddr  = vaddr & PPC32_MIN_PAGE_MASK;
       map.paddr  = vaddr & PPC32_MIN_PAGE_MASK;
+      map.offset = vaddr & PPC32_MIN_PAGE_IMASK;
       map.cached = FALSE;
 
       if (!(entry = ppc32_mem_map(cpu,op_type,&map,entry,alt_entry)))
@@ -680,6 +681,7 @@ static mts32_entry_t *ppc405_slow_lookup(cpu_ppc_t *cpu,m_uint32_t vaddr,
       if ((vaddr & mask) == (tlb_entry->tlb_hi & mask)) {
          map.vaddr  = vaddr & mask;
          map.paddr  = tlb_entry->tlb_lo & mask;
+         map.offset = vaddr & !mask;
          map.cached = FALSE;
 
          if (!(entry = ppc32_mem_map(cpu,op_type,&map,entry,alt_entry)))

--- a/unstable/ppc32_mem.c
+++ b/unstable/ppc32_mem.c
@@ -688,6 +688,7 @@ static mts32_entry_t *ppc405_slow_lookup(cpu_ppc_t *cpu,m_uint32_t vaddr,
    {
       map.vaddr  = vaddr & PPC32_MIN_PAGE_MASK;
       map.paddr  = vaddr & PPC32_MIN_PAGE_MASK;
+      map.offset = vaddr & PPC32_MIN_PAGE_IMASK;
       map.cached = FALSE;
 
       if (!(entry = ppc32_mem_map(cpu,op_type,&map,entry,alt_entry)))
@@ -715,6 +716,7 @@ static mts32_entry_t *ppc405_slow_lookup(cpu_ppc_t *cpu,m_uint32_t vaddr,
       if ((vaddr & mask) == (tlb_entry->tlb_hi & mask)) {
          map.vaddr  = vaddr & mask;
          map.paddr  = tlb_entry->tlb_lo & mask;
+         map.offset = vaddr & !mask;
          map.cached = FALSE;
 
          if (!(entry = ppc32_mem_map(cpu,op_type,&map,entry,alt_entry)))


### PR DESCRIPTION
The field mts_map_t.offset was uninitialized.
This causes ppc32_mem_map to get unpredictable memory.

This code is only used when the pvr register is PPC32_PVR_405.
Only ppc32_vmtest_init_platform sets that and the line is commented out.
Therefore no platforms are affected and it was still in development.