### PR TITLE
Fix update of the LX970A_ISR register in mpc860_fec_mii_read_access

### DIFF
--- a/common/dev_mpc860.c
+++ b/common/dev_mpc860.c
@@ -1515,7 +1515,7 @@ static void mpc860_fec_mii_read_access(struct mpc860_data *d,
             d->fec_mii_regs[reg] &= LX970A_SR_LINKSTATUS;
          }
          break;
-      case LX970A_ISR_MINT:
+      case LX970A_ISR:
          if (d->fec_mii_last_read_reg == LX970A_SR) {
             d->fec_mii_regs[reg] &= ~LX970A_ISR_MINT;
          }


### PR DESCRIPTION
This is probably a copy-paste error.
The MIIT bit (interrupt pending) would never be cleared.
It is suposed to be cleared by reading LX970A_SR, then LX970A_ISR.

The previous code has the MITT bit hardcoded to 0.
We never set the MIIT bit to 1.
Therefore not clearing it has no side effects.

An out-of-bound write would happen for the reg value of LX970A_ISR_MINT.
The mask+shift code in mpc860_fec_mii_access prevents that.
Therefore there is no memory corruption.

Since: 883232925d76ea7b03672e7a63d1b26ca08960c0