### PR TITLE
Fix out-of-bounds read in hex_decode

### DIFF
--- a/common/utils.c
+++ b/common/utils.c
@@ -200,7 +200,7 @@ int hex_decode(unsigned char *out,const unsigned char *in,int maxlen)
    int empty = TRUE;
 
    for(;len < maxlen;) {
-      if (*in > sizeof(hexval) || hexval[*in] == BAD)
+      if (*in >= sizeof(hexval) || hexval[*in] == BAD)
          break;
 
       if (empty) {


### PR DESCRIPTION
The range check is off by 1.
The input letter 'p' makes an out-of-bounds read.
The resulting byte is unpredictable.

Affects the `<bytes>` argument of the command "vm_debug pmem_cfind".

Since: 7ba3d15c22f4d9fd469b004021bf216ae957c483