### PR TITLE
Fix out-of-bounds read in mpc860_idma_fetch_bd

### DIFF
--- a/common/dev_mpc860.c
+++ b/common/dev_mpc860.c
@@ -536,7 +536,7 @@ static void mpc860_idma_transfer(struct mpc860_data *d,
 static int mpc860_idma_fetch_bd(struct mpc860_data *d,m_uint16_t bd_addr,
                                 struct mpc860_idma_bd *bd)
 {
-   if ((bd_addr < MPC860_DPRAM_OFFSET) || (bd_addr > MPC860_DPRAM_END))
+   if ((bd_addr < MPC860_DPRAM_OFFSET) || (bd_addr >= MPC860_DPRAM_END - MPC860_IDMA_BD_SIZE))
       return(-1);
 
    bd->offset = bd_addr - MPC860_DPRAM_OFFSET;


### PR DESCRIPTION
The range check was off by 1.
The range check did not consider the 16 bytes that will be read.
Unpredictable data would be read near the end of the buffer.

Affects platforms with mpc860 (C1700, C2600).

Since: dda4ce3a59325e3b39b135efb1ad40e1161d59a1