### PR TITLE
Fix next offset in mpc860_idma_start_channel

### DIFF
--- a/common/dev_mpc860.c
+++ b/common/dev_mpc860.c
@@ -608,7 +608,7 @@ static int mpc860_idma_start_channel(struct mpc860_data *d,u_int id)
          break;
       }
 
-      bd_offset += sizeof(MPC860_IDMA_BD_SIZE);
+      bd_offset += MPC860_IDMA_BD_SIZE;
    }
 
    mpc860_idma_update_idsr(d,id);


### PR DESCRIPTION
It was increasing bd_offset by 4 instead of 16.

With only 1 bd descriptor available, there were no side effects.
With 2 or more bd descriptors available, it would read garbage and possibly corrupt the first descriptor.

Affects platforms with mpc860 (C1700, C2600).

Since: dda4ce3a59325e3b39b135efb1ad40e1161d59a1