### PR TITLE
Fix out-of-range read in mpc860_scc_fetch_bd.

### DIFF
--- a/common/dev_mpc860.c
+++ b/common/dev_mpc860.c
@@ -862,7 +862,7 @@ static int mpc860_scc_update_irq(struct mpc860_data *d,u_int scc_chan)
 static int mpc860_scc_fetch_bd(struct mpc860_data *d,m_uint16_t bd_addr,
                                struct mpc860_scc_bd *bd)
 {
-   if ((bd_addr < MPC860_DPRAM_OFFSET) || (bd_addr > MPC860_DPRAM_END))
+   if ((bd_addr < MPC860_DPRAM_OFFSET) || (bd_addr >= MPC860_DPRAM_END - MPC860_SCC_BD_SIZE))
       return(-1);
 
    bd->offset = bd_addr - MPC860_DPRAM_OFFSET;


### PR DESCRIPTION
The range check was off by 1.
The range check did not consider the 8 bytes that will be read.
Unpredictable data would be read near the end of the buffer.

Affects platforms with mpc860 (C1700, C2600).

Since: 1150830cf4a3e29ef8c8f831e7b1bdb8f1f217ca