### PR TITLE
Fix the volume_sectors recorded in the boot sector of fat16.

### DIFF
--- a/common/fs_fat.c
+++ b/common/fs_fat.c
@@ -48,8 +48,8 @@ static struct {
 static inline void set_u32(m_uint8_t *p, size_t i, m_uint32_t v) {
    p[i+0] = (m_uint8_t)((v>>0)&0xFF);
    p[i+1] = (m_uint8_t)((v>>8)&0xFF);
-   p[i+1] = (m_uint8_t)((v>>16)&0xFF);
-   p[i+1] = (m_uint8_t)((v>>24)&0xFF);
+   p[i+2] = (m_uint8_t)((v>>16)&0xFF);
+   p[i+3] = (m_uint8_t)((v>>24)&0xFF);
 }
 
 static inline void set_u16(m_uint8_t *p, size_t i, m_uint16_t v) {


### PR DESCRIPTION
The function set_u32 was only setting the lowest byte correctly.
The function is only used to record volume_sectors in the fat16 boot sector.
Affects new pcmcia disks that end up with nr_sectors > 255.

Since: c92054494b4bbf72efbd96eefeb8acfea89fb504