### PR TITLE
Fix unintended sign extention in get_current_time.

### DIFF
--- a/common/dev_nvram.c
+++ b/common/dev_nvram.c
@@ -55,9 +55,9 @@ static m_uint64_t get_current_time(cpu_gen_t *cpu)
    clock_gettime(CLOCK_REALTIME, &spec);
    gmtime_r(&spec.tv_sec, &tmx);
 
-   res =  u8_to_bcd(tmx.tm_sec)  << 8;
-   res += u8_to_bcd(tmx.tm_min)  << 16;
-   res += u8_to_bcd(tmx.tm_hour) << 24;
+   res =  ((m_uint64_t)(u8_to_bcd(tmx.tm_sec)))  << 8;
+   res += ((m_uint64_t)(u8_to_bcd(tmx.tm_min)))  << 16;
+   res += ((m_uint64_t)(u8_to_bcd(tmx.tm_hour))) << 24;
    res += ((m_uint64_t)(u8_to_bcd(tmx.tm_wday))) << 32;
    res += ((m_uint64_t)(u8_to_bcd(tmx.tm_mday))) << 40;
    res += ((m_uint64_t)(u8_to_bcd(tmx.tm_mon+1))) << 48;


### PR DESCRIPTION
Following C rules, u8_to_bcd(tmx.tm_hour) is converted to int, then shifted left by 24, then sign extended to int64, then converted to uint64.
If the byte is greater than 0x7f, then the sign extend will set the upper bits of uint64 to 1.
tmx.tm_hour has the range from 0 to 23 which translates to 0x00 and 0x23.
Therefore there were no side effects.