### PR TITLE
Fix unintentional integer overflow in ppc32_slow_lookup.

### DIFF
--- a/stable/ppc32_mem.c
+++ b/stable/ppc32_mem.c
@@ -360,9 +360,9 @@ static mts32_entry_t *ppc32_slow_lookup(cpu_ppc_t *cpu,m_uint32_t vaddr,
 
  pte_lookup_done:
    pte2  = vmtoh32(*(m_uint32_t *)(pte_haddr + sizeof(m_uint32_t)));
-   paddr =   pte2 & PPC32_PTEL_RPN_MASK;
-   paddr |= (pte2 & PPC32_PTEL_XPN_MASK) << (33 - PPC32_PTEL_XPN_SHIFT);
-   paddr |= (pte2 & PPC32_PTEL_X_MASK) << (32 - PPC32_PTEL_X_SHIFT);
+   paddr =  ((m_uint64_t)(pte2 & PPC32_PTEL_RPN_MASK));
+   paddr |= ((m_uint64_t)(pte2 & PPC32_PTEL_XPN_MASK)) << (33 - PPC32_PTEL_XPN_SHIFT);
+   paddr |= ((m_uint64_t)(pte2 & PPC32_PTEL_X_MASK)) << (32 - PPC32_PTEL_X_SHIFT);
 
    map.vaddr  = vaddr & ~PPC32_MIN_PAGE_IMASK;
    map.paddr  = paddr;

--- a/unstable/ppc32_mem.c
+++ b/unstable/ppc32_mem.c
@@ -363,9 +363,9 @@ static mts32_entry_t *ppc32_slow_lookup(cpu_ppc_t *cpu,m_uint32_t vaddr,
 
  pte_lookup_done:
    pte2  = vmtoh32(*(m_uint32_t *)(pte_haddr + sizeof(m_uint32_t)));
-   paddr =   pte2 & PPC32_PTEL_RPN_MASK;
-   paddr |= (pte2 & PPC32_PTEL_XPN_MASK) << (33 - PPC32_PTEL_XPN_SHIFT);
-   paddr |= (pte2 & PPC32_PTEL_X_MASK) << (32 - PPC32_PTEL_X_SHIFT);
+   paddr =  ((m_uint64_t)(pte2 & PPC32_PTEL_RPN_MASK));
+   paddr |= ((m_uint64_t)(pte2 & PPC32_PTEL_XPN_MASK)) << (33 - PPC32_PTEL_XPN_SHIFT);
+   paddr |= ((m_uint64_t)(pte2 & PPC32_PTEL_X_MASK)) << (32 - PPC32_PTEL_X_SHIFT);
 
    map.vaddr  = vaddr & ~PPC32_MIN_PAGE_IMASK;
    map.paddr  = paddr;


### PR DESCRIPTION
The shift happens before the uint32->uint64 conversion. The uint32 type has bits 31-0.
The PPC32_PTEL_XPN bits end up in bits 35-34.
The PPC32_PTEL_X bit ends up in bit 32.
Therefore these bits are always set to 0.

Affects platforms with a ppc32 cpu (C1700, C2600, C7200 with npe-g2).

Since: dda4ce3a59325e3b39b135efb1ad40e1161d59a1