### PR TITLE
Fix unintended sign extension in dev_c7200_mpfpga_access.

### DIFF
--- a/common/dev_c7200_mpfpga.c
+++ b/common/dev_c7200_mpfpga.c
@@ -245,9 +245,9 @@ void *dev_c7200_mpfpga_access(cpu_gen_t *cpu,struct vdevice *dev,
                offset = dev_c7200_net_get_reg_offset(0);               
 
                if (router->net_irq_status[2]) {
-                  *data |= 0xFF << offset;
+                  *data |= ((m_uint64_t)0xFF) << offset;
                } else {
-                  *data &= ~(0xFF << offset);
+                  *data &= ~(((m_uint64_t)0xFF) << offset);
                }
             }
          }


### PR DESCRIPTION
Following C rules, 0xFF is converted to int, then shifted left by offset, then sign extended to int64, then converted to uint64.
If offset is 24, then the sign extend will set the upper bits of uint64 to 1.
Side effects are unknown, probably non-existent.