### PR TITLE
Warn when SO_REUSEADDR is not set.

### DIFF
--- a/common/net.c
+++ b/common/net.c
@@ -333,11 +333,14 @@ int udp_connect(int local_port,char *remote_host,int remote_port)
       }
 
       /* try to connect to remote host */
-      setsockopt(sck, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+      error = setsockopt(sck, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
       if (!bind(sck,(struct sockaddr *)&st,res->ai_addrlen) &&
           !connect(sck,res->ai_addr,res->ai_addrlen))
          break;
 
+      if (error) {
+         fprintf(stderr,"Warning: udp_connect: SO_REUSEADDR is not set. The same address-port combination can be retried after the TIME_WAIT state expires.");
+      }
       close(sck);
       sck = -1;
    }
@@ -377,9 +380,12 @@ int udp_connect(int local_port,char *remote_host,int remote_port)
    sin.sin_family = PF_INET;
    sin.sin_port = htons(local_port);
 
-   setsockopt(sck, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+   error = setsockopt(sck, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
    if (bind(sck,(struct sockaddr *)&sin,sizeof(sin)) < 0) {
       perror("udp_connect: bind");
+      if (error) {
+         fprintf(stderr,"Warning: udp_connect: SO_REUSEADDR is not set. The same address-port combination can be retried after the TIME_WAIT state expires.");
+      }
       close(sck);
       return(-1);
    }

--- a/common/net.c
+++ b/common/net.c
@@ -440,11 +440,14 @@ int ip_listen(char *ip_addr,int port,int sock_type,int max_fd,int fd_array[])
       if (fd_array[nsock] < 0)
          continue;      
 
-      setsockopt(fd_array[nsock],SOL_SOCKET,SO_REUSEADDR,&reuse,sizeof(reuse));
+      error = setsockopt(fd_array[nsock],SOL_SOCKET,SO_REUSEADDR,&reuse,sizeof(reuse));
 
       if ((bind(fd_array[nsock],res->ai_addr,res->ai_addrlen) < 0) ||
           ((sock_type == SOCK_STREAM) && (listen(fd_array[nsock],5) < 0)))
       {
+         if (error) {
+            fprintf(stderr,"Warning: ip_listen: SO_REUSEADDR is not set. The same address-port combination can be retried after the TIME_WAIT state expires.");
+         }
          close(fd_array[nsock]);
          fd_array[nsock] = -1;
          continue;
@@ -479,7 +482,7 @@ int ip_listen(char *ip_addr,int port,int sock_type,int max_fd,int fd_array[])
    if (ip_addr && strlen(ip_addr))
       sin.sin_addr.s_addr = inet_addr(ip_addr);
 
-   setsockopt(sck,SOL_SOCKET,SO_REUSEADDR,&reuse,sizeof(reuse));
+   error = setsockopt(sck,SOL_SOCKET,SO_REUSEADDR,&reuse,sizeof(reuse));
 
    if (bind(sck,(struct sockaddr *)&sin,sizeof(sin)) < 0) {
       perror("ip_listen: bind");
@@ -495,6 +498,9 @@ int ip_listen(char *ip_addr,int port,int sock_type,int max_fd,int fd_array[])
    return(1);
 
  error:
+   if (error) {
+      fprintf(stderr,"Warning: ip_listen: SO_REUSEADDR is not set. The same address-port combination can be retried after the TIME_WAIT state expires.");
+   }
    close(sck);
    return(-1);
 }


### PR DESCRIPTION
This is a "minimum effort" warning.
When a socket bind/listen fails without SO_REUSEADDR then the ip-port combination might be in the TIME_WAIT state.
There is no way to test if that is actual case, so just warn the user.