### PR TITLE
Warn when a file rename fails while renaming a vm.

### DIFF
--- a/stable/vm.c
+++ b/stable/vm.c
@@ -1230,7 +1230,9 @@ int vm_rename_instance(vm_instance_t *vm, char *name)
          if ((filename = dyn_sprintf("%s_%s_%s",vm_get_type(vm),vm->name,globbuf.gl_pathv[i] + strlen(pattern) - 1)) == NULL)
             break; /* out of memory */
 
-         rename(globbuf.gl_pathv[i], filename);
+         if (rename(globbuf.gl_pathv[i], filename) != 0) {
+            fprintf(stderr, "Warning: vm_rename_instance: rename(\"%s\",\"%s\"): %s\n", globbuf.gl_pathv[i], filename, strerror(errno));
+         }
          free(filename);
       }
       globfree(&globbuf);

--- a/unstable/vm.c
+++ b/unstable/vm.c
@@ -1230,7 +1230,9 @@ int vm_rename_instance(vm_instance_t *vm, char *name)
          if ((filename = dyn_sprintf("%s_%s_%s",vm_get_type(vm),vm->name,globbuf.gl_pathv[i] + strlen(pattern) - 1)) == NULL)
             break; /* out of memory */
 
-         rename(globbuf.gl_pathv[i], filename);
+         if (rename(globbuf.gl_pathv[i], filename) != 0) {
+            fprintf(stderr, "Warning: vm_rename_instance: rename(\"%s\",\"%s\"): %s\n", globbuf.gl_pathv[i], filename, strerror(errno));
+         }
          free(filename);
       }
       globfree(&globbuf);


### PR DESCRIPTION
This is a "minimum effort" warning.
Multiple files are being renamed.
When a vm file is not renamed correctly then the vm will be in an unknown state.
The user will need to fix the filenames manually.