### PR TITLE
Fix sizeof type in parser_map_array.

### DIFF
--- a/common/parser.c
+++ b/common/parser.c
@@ -73,7 +73,7 @@ char **parser_map_array(parser_context_t *ctx)
    if (ctx->tok_count <= 0)
       return NULL;
 
-   if (!(map = calloc(ctx->tok_count,sizeof(char **))))
+   if (!(map = calloc(ctx->tok_count,sizeof(char *))))
       return NULL;
 
    for(i=0,tok=ctx->tok_head;(i<ctx->tok_count) && tok;i++,tok=tok->next)


### PR DESCRIPTION
The wrong type was being used, probably a copy-paste error.