### PR TITLE
Ensure the full vtty replay buffer is sent.

### DIFF
--- a/common/dev_vtty.h
+++ b/common/dev_vtty.h
@@ -89,6 +89,7 @@ struct virtual_tty {
    /* Old text for replay */
    u_char replay_buffer[VTTY_BUFFER_SIZE];
    u_int replay_ptr;
+   u_char replay_full;
 };
 
 #define VTTY_LOCK(tty) pthread_mutex_lock(&(tty)->lock);


### PR DESCRIPTION
`send` is allowed to send only part of the buffer.
Assuming it sends everything could cause information loss.

A non-full replay buffer was detected with nul bytes.
This means valid nul bytes could be skipped while sending the replay buffer.
Now it remembers if the buffer is full with `vtty->replay_full`.