### PR TITLE
Clear uninitialized sections in ppc32_load_elf_image.

### DIFF
--- a/stable/ppc32.c
+++ b/stable/ppc32.c
@@ -639,11 +639,16 @@ int ppc32_load_elf_image(cpu_ppc_t *cpu,char *filename,int skip_load,
 
             clen = m_min(clen,remain);
 
-            if (fread((u_char *)haddr,clen,1,bfd) != 1) {
-               perror("load_elf_image: fread");
-               elf_end(img_elf);
-               fclose(bfd);
-               return(-1);
+            if (shdr->sh_type == SHT_NOBITS) {
+               // section with uninitialized data, zero it
+               memset((u_char *)haddr, 0, clen);
+            } else {
+               if (fread((u_char *)haddr,clen,1,bfd) != 1) {
+                  perror("load_elf_image: fread");
+                  elf_end(img_elf);
+                  fclose(bfd);
+                  return(-1);
+               }
             }
 
             vaddr += clen;

--- a/unstable/ppc32.c
+++ b/unstable/ppc32.c
@@ -636,11 +636,16 @@ int ppc32_load_elf_image(cpu_ppc_t *cpu,char *filename,int skip_load,
 
             clen = m_min(clen,remain);
 
-            if (fread((u_char *)haddr,clen,1,bfd) != 1) {
-               perror("load_elf_image: fread");
-               elf_end(img_elf);
-               fclose(bfd);
-               return(-1);
+            if (shdr->sh_type == SHT_NOBITS) {
+               // section with uninitialized data, zero it
+               memset((u_char *)haddr, 0, clen);
+            } else {
+               if (fread((u_char *)haddr,clen,1,bfd) != 1) {
+                  perror("load_elf_image: fread");
+                  elf_end(img_elf);
+                  fclose(bfd);
+                  return(-1);
+               }
             }
 
             vaddr += clen;


### PR DESCRIPTION
Elf sections of type `SHT_NOBITS` do not contain data in the file.
It was either reading junk data or failing to read.