### PR TITLE
Clear uninitialized sections in mips64_load_elf_image.

### DIFF
--- a/stable/mips64.c
+++ b/stable/mips64.c
@@ -1013,11 +1013,16 @@ int mips64_load_elf_image(cpu_mips_t *cpu,char *filename,int skip_load,
 
             clen = m_min(clen,remain);
 
-            if (fread((u_char *)haddr,clen,1,bfd) != 1) {
-               perror("load_elf_image: fread");
-               elf_end(img_elf);
-               fclose(bfd);
-               return(-1);
+            if (shdr->sh_type == SHT_NOBITS) {
+               // section with uninitialized data, zero it
+               memset((u_char *)haddr, 0, clen);
+            } else {
+               if (fread((u_char *)haddr,clen,1,bfd) != 1) {
+                  perror("load_elf_image: fread");
+                  elf_end(img_elf);
+                  fclose(bfd);
+                  return(-1);
+               }
             }
 
             vaddr += clen;

--- a/unstable/mips64.c
+++ b/unstable/mips64.c
@@ -1096,11 +1096,16 @@ int mips64_load_elf_image(cpu_mips_t *cpu,char *filename,int skip_load,
 
             clen = m_min(clen,remain);
 
-            if (fread((u_char *)haddr,clen,1,bfd) != 1) {
-               perror("load_elf_image: fread");
-               elf_end(img_elf);
-               fclose(bfd);
-               return(-1);
+            if (shdr->sh_type == SHT_NOBITS) {
+               // section with uninitialized data, zero it
+               memset((u_char *)haddr, 0, clen);
+            } else {
+               if (fread((u_char *)haddr,clen,1,bfd) != 1) {
+                  perror("load_elf_image: fread");
+                  elf_end(img_elf);
+                  fclose(bfd);
+                  return(-1);
+               }
             }
 
             vaddr += clen;


### PR DESCRIPTION
Elf sections of type `SHT_NOBITS` do not contain data in the file.
It was either reading junk data or failing to read.