### PR TITLE
Fix format type in cmd_parser_test.

### DIFF
--- a/unstable/hypervisor.c
+++ b/unstable/hypervisor.c
@@ -68,7 +68,7 @@ static int cmd_parser_test(hypervisor_conn_t *conn,int argc,char *argv[])
 
    for(i=0;i<argc;i++)
       hypervisor_send_reply(conn,HSC_INFO_MSG,0,
-                            "arg %d (len %u): \"%s\"",
+                            "arg %d (len %lu): \"%s\"",
                             i,strlen(argv[i]),argv[i]);
 
    hypervisor_send_reply(conn,HSC_INFO_OK,1,"OK");


### PR DESCRIPTION
The stable version was fixed in d440d47c1ae31bd7b28fd2dbe816872ef0f07ea4