### PR TITLE
Fix copy-paste error in mips64_cp0_tlb_lookup.

### DIFF
--- a/unstable/mips64_cp0.c
+++ b/unstable/mips64_cp0.c
@@ -419,7 +419,7 @@ int mips64_cp0_tlb_lookup(cpu_mips_t *cpu,m_uint64_t vaddr,
                pca >>= MIPS_TLB_C_SHIFT;
                res->cached = mips64_cca_cached(pca);     
                                              
-               if (!(entry->lo0 & MIPS_TLB_D_MASK))
+               if (!(entry->lo1 & MIPS_TLB_D_MASK))
                   res->flags |= MTS_FLAG_RO;
                          
                return(MIPS_TLB_LOOKUP_OK);


### PR DESCRIPTION
Odd pages had `MTS_FLAG_RO` set based on the value for the even pages.
This could result in read-only pages being treated as writable, and writable pages being treated as read-only.