### PR TITLE
Fix data race in dev_i8254x_handle_txring.

### DIFF
--- a/common/dev_i8254x.c
+++ b/common/dev_i8254x.c
@@ -906,12 +906,12 @@ static int dev_i8254x_handle_txring(struct i8254x_data *d)
 {
    int res,i;
 
-   /* Transmit Enabled ? */
-   if (!(d->tctl & I8254X_TCTL_EN))
-      return(FALSE);
-
    for(i=0;i<I8254X_TXRING_PASS_COUNT;i++) {
       LVG_LOCK(d);
+      /* Transmit Enabled ? */
+      if (!(d->tctl & I8254X_TCTL_EN))
+         break;
+
       res = dev_i8254x_handle_txring_single(d);
       LVG_UNLOCK(d);
 


### PR DESCRIPTION
The value of `tctl` is changed while holding the lock.
The manual says setting the bit to 0 should stop sending packets after finishing in-progress packets.
Therefore it should test `tctl` before sending each packet while holding the lock.
`ptask_run` ignores the return value so a break is sufficient.