### PR TITLE
Fix NULL dereference in mips64_get_idling_pc.

### DIFF
--- a/unstable/mips64.c
+++ b/unstable/mips64.c
@@ -228,6 +228,10 @@ int mips64_get_idling_pc(cpu_gen_t *cpu)
    printf("\nPlease wait while gathering statistics...\n");
 
    pc_hash = calloc(IDLE_HASH_SIZE,sizeof(struct mips64_idle_pc_hash *));
+   if (pc_hash == NULL) {
+      printf("Out of memory.");
+      return(-1);
+   }
 
    /* Disable IRQ */
    mcpu->irq_disable = TRUE;


### PR DESCRIPTION
This code was missing from #220