### PR TITLE
Fix debugging/log message in dev_remote_control_access.

### DIFF
--- a/common/dev_remote.c
+++ b/common/dev_remote.c
@@ -165,11 +165,10 @@ void *dev_remote_control_access(cpu_gen_t *cpu,struct vdevice *dev,
       /* Debugging/Log message: /!\ physical address */
       case 0x038:
          if (op_type == MTS_WRITE) {
-            len = physmem_strlen(vm,*data);
-            if (len < sizeof(d->con_buffer)) {
-               physmem_copy_from_vm(vm,d->con_buffer,*data,len+1);
-               vm_log(vm,"ROM",d->con_buffer);
-            }
+            len = physmem_strnlen(vm,*data,sizeof(d->con_buffer));
+            physmem_copy_from_vm(vm,d->con_buffer,*data,len);
+            d->con_buffer[m_min(len,sizeof(d->con_buffer)-1)] = 0;
+            vm_log(vm,"ROM","%s",d->con_buffer);
          }
          break;
 

--- a/common/memory.c
+++ b/common/memory.c
@@ -294,16 +294,17 @@ void physmem_dma_transfer(vm_instance_t *vm,m_uint64_t src,m_uint64_t dst,
    }
 }
 
-/* strlen in VM physical memory */
-size_t physmem_strlen(vm_instance_t *vm,m_uint64_t paddr)
+/* strnlen in VM physical memory */
+size_t physmem_strnlen(vm_instance_t *vm,m_uint64_t paddr,size_t maxlen)
 {
    struct vdevice *vm_ram;
    size_t len = 0;
    char *ptr;
    
-   if ((vm_ram = dev_lookup(vm,paddr,TRUE)) != NULL) {
+   if ((vm_ram = dev_lookup(vm,paddr,TRUE)) != NULL && vm_ram->host_addr) {
       ptr = (char *)vm_ram->host_addr + (paddr - vm_ram->phys_addr);
-      len = strlen(ptr);
+      maxlen = m_min(maxlen, vm_ram->phys_len - (paddr - vm_ram->phys_addr));
+      len = strnlen(ptr,maxlen);
    }
 
    return(len);

--- a/stable/memory.h
+++ b/stable/memory.h
@@ -112,8 +112,8 @@ void physmem_copy_u8_to_vm(vm_instance_t *vm,m_uint64_t paddr,m_uint8_t val);
 void physmem_dma_transfer(vm_instance_t *vm,m_uint64_t src,m_uint64_t dst,
                           size_t len);
 
-/* strlen in VM physical memory */
-size_t physmem_strlen(vm_instance_t *vm,m_uint64_t paddr);
+/* strnlen in VM physical memory */
+size_t physmem_strnlen(vm_instance_t *vm,m_uint64_t paddr,size_t maxlen);
 
 /* find sequence of bytes in VM cacheable physical memory interval [first,last] */
 int physmem_cfind(vm_instance_t *vm,m_uint8_t *bytes,size_t len,

--- a/unstable/memory.h
+++ b/unstable/memory.h
@@ -119,8 +119,8 @@ void physmem_copy_u8_to_vm(vm_instance_t *vm,m_uint64_t paddr,m_uint8_t val);
 void physmem_dma_transfer(vm_instance_t *vm,m_uint64_t src,m_uint64_t dst,
                           size_t len);
 
-/* strlen in VM physical memory */
-size_t physmem_strlen(vm_instance_t *vm,m_uint64_t paddr);
+/* strnlen in VM physical memory */
+size_t physmem_strnlen(vm_instance_t *vm,m_uint64_t paddr,size_t maxlen);
 
 /* find sequence of bytes in VM cacheable physical memory interval [first,last] */
 int physmem_cfind(vm_instance_t *vm,m_uint8_t *bytes,size_t len,


### PR DESCRIPTION
Fills the console buffer, makes sure it is nul-terminated, and logs it.

physmem_strlen was changed:
 - checks that the memory is not null
 - reads up to maxlen bytes
 - stops reading at the end of the device
 - renamed to physmem_strnlen

Fixes #252