### PR TITLE
Add more checks to ilt_create.

### DIFF
--- a/common/insn_lookup.h
+++ b/common/insn_lookup.h
@@ -64,6 +64,7 @@ struct rfc_eqclass {
 
 /* Instruction lookup table */
 struct insn_lookup {
+   m_uint32_t crc32_insn; /* crc32 of the mask and value of all the instructions */
    int nr_insn;    /* Number of instructions */
    int cbm_size;   /* Size of Class Bitmaps */
 
@@ -96,7 +97,7 @@ static forced_inline int ilt_lookup(insn_lookup_t *ilt,mips_insn_t insn)
 }
 
 /* Create an instruction lookup table */
-insn_lookup_t *ilt_create(char *table_name,
+insn_lookup_t *ilt_create(char *table_name,m_uint32_t crc32,
                           int nr_insn,ilt_get_insn_cbk_t get_insn,
                           ilt_check_cbk_t chk_lo,ilt_check_cbk_t chk_hi);
 

--- a/stable/mips64_exec.c
+++ b/stable/mips64_exec.c
@@ -22,6 +22,7 @@
 #include "memory.h"
 #include "insn_lookup.h"
 #include "dynamips.h"
+#include "crc.h"
 
 /* Forward declaration of instruction array */
 static struct mips64_insn_exec_tag mips64_exec_tags[];
@@ -55,11 +56,15 @@ static void destroy_ilt(void)
 void mips64_exec_create_ilt(void)
 {
    int i,count;
+   m_uint32_t crc32 = 0;
 
-   for(i=0,count=0;mips64_exec_tags[i].exec;i++)
+   for(i=0,count=0;mips64_exec_tags[i].exec;i++) {
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&mips64_exec_tags[i].mask,sizeof(mips64_exec_tags[i].mask));
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&mips64_exec_tags[i].value,sizeof(mips64_exec_tags[i].value));
       count++;
+   }
 
-   ilt = ilt_create("mips64e",count,
+   ilt = ilt_create("mips64e",crc32,count,
                     (ilt_get_insn_cbk_t)mips64_exec_get_insn,
                     (ilt_check_cbk_t)mips64_exec_chk_lo,
                     (ilt_check_cbk_t)mips64_exec_chk_hi);

--- a/stable/mips64_jit.c
+++ b/stable/mips64_jit.c
@@ -25,6 +25,7 @@
 #include "insn_lookup.h"
 #include "memory.h"
 #include "ptask.h"
+#include "crc.h"
 
 #include MIPS64_ARCH_INC_FILE
 
@@ -86,11 +87,15 @@ static void destroy_ilt(void)
 void mips64_jit_create_ilt(void)
 {
    int i,count;
+   m_uint32_t crc32 = 0;
 
-   for(i=0,count=0;mips64_insn_tags[i].emit;i++)
+   for(i=0,count=0;mips64_insn_tags[i].emit;i++) {
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&mips64_insn_tags[i].mask,sizeof(mips64_insn_tags[i].mask));
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&mips64_insn_tags[i].value,sizeof(mips64_insn_tags[i].value));
       count++;
+   }
 
-   ilt = ilt_create("mips64j",count,
+   ilt = ilt_create("mips64j",crc32,count,
                     (ilt_get_insn_cbk_t)mips64_jit_get_insn,
                     (ilt_check_cbk_t)mips64_jit_chk_lo,
                     (ilt_check_cbk_t)mips64_jit_chk_hi);

--- a/stable/ppc32_exec.c
+++ b/stable/ppc32_exec.c
@@ -21,6 +21,7 @@
 #include "memory.h"
 #include "insn_lookup.h"
 #include "dynamips.h"
+#include "crc.h"
 
 /* Forward declaration of instruction array */
 static struct ppc32_insn_exec_tag ppc32_exec_tags[];
@@ -54,11 +55,15 @@ static void destroy_ilt(void)
 void ppc32_exec_create_ilt(void)
 {
    int i,count;
+   m_uint32_t crc32 = 0;
 
-   for(i=0,count=0;ppc32_exec_tags[i].exec;i++)
+   for(i=0,count=0;ppc32_exec_tags[i].exec;i++) {
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&ppc32_exec_tags[i].mask,sizeof(ppc32_exec_tags[i].mask));
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&ppc32_exec_tags[i].value,sizeof(ppc32_exec_tags[i].value));
       count++;
+   }
 
-   ilt = ilt_create("ppc32e",count,
+   ilt = ilt_create("ppc32e",crc32,count,
                     (ilt_get_insn_cbk_t)ppc32_exec_get_insn,
                     (ilt_check_cbk_t)ppc32_exec_chk_lo,
                     (ilt_check_cbk_t)ppc32_exec_chk_hi);

--- a/stable/ppc32_jit.c
+++ b/stable/ppc32_jit.c
@@ -23,6 +23,7 @@
 #include "insn_lookup.h"
 #include "memory.h"
 #include "ptask.h"
+#include "crc.h"
 
 #include PPC32_ARCH_INC_FILE
 
@@ -56,11 +57,15 @@ static void destroy_ilt(void)
 void ppc32_jit_create_ilt(void)
 {
    int i,count;
+   m_uint32_t crc32 = 0;
 
-   for(i=0,count=0;ppc32_insn_tags[i].emit;i++)
+   for(i=0,count=0;ppc32_insn_tags[i].emit;i++) {
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&ppc32_insn_tags[i].mask,sizeof(ppc32_insn_tags[i].mask));
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&ppc32_insn_tags[i].value,sizeof(ppc32_insn_tags[i].value));
       count++;
+   }
 
-   ilt = ilt_create("ppc32j",count,
+   ilt = ilt_create("ppc32j",crc32,count,
                     (ilt_get_insn_cbk_t)ppc32_jit_get_insn,
                     (ilt_check_cbk_t)ppc32_jit_chk_lo,
                     (ilt_check_cbk_t)ppc32_jit_chk_hi);

--- a/unstable/mips64_exec.c
+++ b/unstable/mips64_exec.c
@@ -22,6 +22,7 @@
 #include "memory.h"
 #include "insn_lookup.h"
 #include "dynamips.h"
+#include "crc.h"
 
 /* Forward declaration of instruction array */
 static struct mips64_insn_exec_tag mips64_exec_tags[];
@@ -55,11 +56,15 @@ static void destroy_ilt(void)
 void mips64_exec_create_ilt(void)
 {
    int i,count;
+   m_uint32_t crc32 = 0;
 
-   for(i=0,count=0;mips64_exec_tags[i].exec;i++)
+   for(i=0,count=0;mips64_exec_tags[i].exec;i++) {
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&mips64_exec_tags[i].mask,sizeof(mips64_exec_tags[i].mask));
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&mips64_exec_tags[i].value,sizeof(mips64_exec_tags[i].value));
       count++;
+   }
 
-   ilt = ilt_create("mips64e",count,
+   ilt = ilt_create("mips64e",crc32,count,
                     (ilt_get_insn_cbk_t)mips64_exec_get_insn,
                     (ilt_check_cbk_t)mips64_exec_chk_lo,
                     (ilt_check_cbk_t)mips64_exec_chk_hi);

--- a/unstable/mips64_jit.c
+++ b/unstable/mips64_jit.c
@@ -26,6 +26,7 @@
 #include "insn_lookup.h"
 #include "memory.h"
 #include "ptask.h"
+#include "crc.h"
 
 #include MIPS64_ARCH_INC_FILE
 
@@ -89,11 +90,15 @@ static void destroy_ilt(void)
 void mips64_jit_create_ilt(void)
 {
    int i,count;
+   m_uint32_t crc32 = 0;
 
-   for(i=0,count=0;mips64_insn_tags[i].emit;i++)
+   for(i=0,count=0;mips64_insn_tags[i].emit;i++) {
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&mips64_insn_tags[i].mask,sizeof(mips64_insn_tags[i].mask));
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&mips64_insn_tags[i].value,sizeof(mips64_insn_tags[i].value));
       count++;
+   }
 
-   ilt = ilt_create("mips64j",count,
+   ilt = ilt_create("mips64j",crc32,count,
                     (ilt_get_insn_cbk_t)mips64_jit_get_insn,
                     (ilt_check_cbk_t)mips64_jit_chk_lo,
                     (ilt_check_cbk_t)mips64_jit_chk_hi);

--- a/unstable/ppc32_exec.c
+++ b/unstable/ppc32_exec.c
@@ -21,6 +21,7 @@
 #include "memory.h"
 #include "insn_lookup.h"
 #include "dynamips.h"
+#include "crc.h"
 
 /* Forward declaration of instruction array */
 static struct ppc32_insn_exec_tag ppc32_exec_tags[];
@@ -54,11 +55,15 @@ static void destroy_ilt(void)
 void ppc32_exec_create_ilt(void)
 {
    int i,count;
+   m_uint32_t crc32 = 0;
 
-   for(i=0,count=0;ppc32_exec_tags[i].exec;i++)
+   for(i=0,count=0;ppc32_exec_tags[i].exec;i++) {
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&ppc32_exec_tags[i].mask,sizeof(ppc32_exec_tags[i].mask));
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&ppc32_exec_tags[i].value,sizeof(ppc32_exec_tags[i].value));
       count++;
+   }
 
-   ilt = ilt_create("ppc32e",count,
+   ilt = ilt_create("ppc32e",crc32,count,
                     (ilt_get_insn_cbk_t)ppc32_exec_get_insn,
                     (ilt_check_cbk_t)ppc32_exec_chk_lo,
                     (ilt_check_cbk_t)ppc32_exec_chk_hi);

--- a/unstable/ppc32_jit.c
+++ b/unstable/ppc32_jit.c
@@ -23,6 +23,7 @@
 #include "insn_lookup.h"
 #include "memory.h"
 #include "ptask.h"
+#include "crc.h"
 
 #include PPC32_ARCH_INC_FILE
 
@@ -56,11 +57,15 @@ static void destroy_ilt(void)
 void ppc32_jit_create_ilt(void)
 {
    int i,count;
+   m_uint32_t crc32 = 0;
 
-   for(i=0,count=0;ppc32_insn_tags[i].emit;i++)
+   for(i=0,count=0;ppc32_insn_tags[i].emit;i++) {
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&ppc32_insn_tags[i].mask,sizeof(ppc32_insn_tags[i].mask));
+      crc32 = crc32_compute(~crc32,(m_uint8_t*)&ppc32_insn_tags[i].value,sizeof(ppc32_insn_tags[i].value));
       count++;
+   }
 
-   ilt = ilt_create("ppc32j",count,
+   ilt = ilt_create("ppc32j",crc32,count,
                     (ilt_get_insn_cbk_t)ppc32_jit_get_insn,
                     (ilt_check_cbk_t)ppc32_jit_chk_lo,
                     (ilt_check_cbk_t)ppc32_jit_chk_hi);


### PR DESCRIPTION
Compile info is stored, read, and checked:
 - crc32 of the mask and value of all the instructions
 - number of instructions
 - size of Class Bitmaps

The cache will be recompiled if the compile info does not match what is expected.

Fixes #253