### PR TITLE
Remove fastcall/asmlinkage.

### DIFF
--- a/common/dynamips_common.h
+++ b/common/dynamips_common.h
@@ -58,7 +58,6 @@
 #define ARCH_BYTE_ORDER ARCH_LITTLE_ENDIAN
 #elif defined(__i386) || defined(__i386__) || defined(i386)
 #define ARCH_BYTE_ORDER ARCH_LITTLE_ENDIAN
-#define ARCH_REGPARM_SUPPORTED  1
 #elif defined(__x86_64__)
 #define ARCH_BYTE_ORDER ARCH_LITTLE_ENDIAN
 #elif defined(__ia64__)
@@ -77,15 +76,6 @@
 
 #ifndef ARCH_BYTE_ORDER
 #error Please define your architecture!
-#endif
-
-/* Useful attributes for functions */
-#ifdef ARCH_REGPARM_SUPPORTED
-#define asmlinkage __attribute__((regparm(0)))
-#define fastcall   __attribute__((regparm(3)))
-#else
-#define asmlinkage
-#define fastcall
 #endif
 
 #ifndef _Unused

--- a/common/ppc32_exec.h
+++ b/common/ppc32_exec.h
@@ -37,7 +37,7 @@ void ppc32_exec_create_ilt(void);
 void ppc32_dump_stats(cpu_ppc_t *cpu);
 
 /* Execute a page */
-fastcall int ppc32_exec_page(cpu_ppc_t *cpu);
+int ppc32_exec_page(cpu_ppc_t *cpu);
 
 /* Execute a single instruction (external) */
 int ppc32_exec_single_insn_ext(cpu_ppc_t *cpu,ppc_insn_t insn);

--- a/common/ppc32_exec.h
+++ b/common/ppc32_exec.h
@@ -40,6 +40,6 @@ void ppc32_dump_stats(cpu_ppc_t *cpu);
 fastcall int ppc32_exec_page(cpu_ppc_t *cpu);
 
 /* Execute a single instruction (external) */
-fastcall int ppc32_exec_single_insn_ext(cpu_ppc_t *cpu,ppc_insn_t insn);
+int ppc32_exec_single_insn_ext(cpu_ppc_t *cpu,ppc_insn_t insn);
 
 #endif

--- a/common/ppc32_exec.h
+++ b/common/ppc32_exec.h
@@ -11,7 +11,7 @@
 /* PowerPC instruction recognition */
 struct ppc32_insn_exec_tag {
    char *name;
-   fastcall int (*exec)(cpu_ppc_t *,ppc_insn_t);
+   int (*exec)(cpu_ppc_t *,ppc_insn_t);
    m_uint32_t mask,value;
    int instr_type;
    m_uint64_t count;

--- a/stable/mips64.c
+++ b/stable/mips64.c
@@ -542,7 +542,7 @@ void mips64_exec_mtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
 }
 
 /* Virtual breakpoint */
-fastcall void mips64_run_breakpoint(cpu_mips_t *cpu)
+void mips64_run_breakpoint(cpu_mips_t *cpu)
 {
    cpu_log(cpu->gen,"BREAKPOINT",
            "Virtual breakpoint reached at PC=0x%llx\n",cpu->pc);

--- a/stable/mips64.c
+++ b/stable/mips64.c
@@ -492,7 +492,7 @@ void mips64_exec_break(cpu_mips_t *cpu,u_int code)
 }
 
 /* Trigger a Trap Exception */
-fastcall void mips64_trigger_trap_exception(cpu_mips_t *cpu)
+void mips64_trigger_trap_exception(cpu_mips_t *cpu)
 {  
    /* XXX TODO: Branch Delay slot */
    printf("MIPS64: TRAP exception, CPU=%p\n",cpu);

--- a/stable/mips64.c
+++ b/stable/mips64.c
@@ -435,7 +435,7 @@ void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu)
 }
 
 /* Trigger the Timer IRQ */
-fastcall void mips64_trigger_timer_irq(cpu_mips_t *cpu)
+void mips64_trigger_timer_irq(cpu_mips_t *cpu)
 {
    mips_cp0_t *cp0 = &cpu->cp0;
 

--- a/stable/mips64.c
+++ b/stable/mips64.c
@@ -482,7 +482,7 @@ void mips64_exec_syscall(cpu_mips_t *cpu)
 }
 
 /* Execute BREAK instruction */
-fastcall void mips64_exec_break(cpu_mips_t *cpu,u_int code)
+void mips64_exec_break(cpu_mips_t *cpu,u_int code)
 {
    printf("MIPS64: BREAK instruction (code=%u)\n",code);
    mips64_dump_regs(cpu->gen);

--- a/stable/mips64.c
+++ b/stable/mips64.c
@@ -467,7 +467,7 @@ void mips64_exec_eret(cpu_mips_t *cpu)
 }
 
 /* Execute SYSCALL instruction */
-fastcall void mips64_exec_syscall(cpu_mips_t *cpu)
+void mips64_exec_syscall(cpu_mips_t *cpu)
 {
 #if DEBUG_SYSCALL
    printf("MIPS64: SYSCALL at PC=0x%llx (RA=0x%llx)\n"

--- a/stable/mips64.c
+++ b/stable/mips64.c
@@ -447,7 +447,7 @@ void mips64_trigger_timer_irq(cpu_mips_t *cpu)
 }
 
 /* Execute ERET instruction */
-fastcall void mips64_exec_eret(cpu_mips_t *cpu)
+void mips64_exec_eret(cpu_mips_t *cpu)
 {
    mips_cp0_t *cp0 = &cpu->cp0;
 

--- a/stable/mips64.c
+++ b/stable/mips64.c
@@ -595,7 +595,7 @@ void mips64_remove_breakpoint(cpu_gen_t *cpu,m_uint64_t pc)
 }
 
 /* Debugging for register-jump to address 0 */
-fastcall void mips64_debug_jr0(cpu_mips_t *cpu)
+void mips64_debug_jr0(cpu_mips_t *cpu)
 {
    printf("MIPS64: cpu %p jumping to address 0...\n",cpu);
    mips64_dump_regs(cpu->gen);

--- a/stable/mips64.c
+++ b/stable/mips64.c
@@ -515,19 +515,19 @@ fastcall void mips64_trigger_irq(cpu_mips_t *cpu)
 }
 
 /* DMFC1 */
-fastcall void mips64_exec_dmfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
+void mips64_exec_dmfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
 {
    cpu->gpr[gp_reg] = cpu->fpu.reg[cp1_reg];
 }
 
 /* DMTC1 */
-fastcall void mips64_exec_dmtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
+void mips64_exec_dmtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
 {
    cpu->fpu.reg[cp1_reg] = cpu->gpr[gp_reg];
 }
 
 /* MFC1 */
-fastcall void mips64_exec_mfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
+void mips64_exec_mfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
 {
    m_int64_t val;
 
@@ -536,7 +536,7 @@ fastcall void mips64_exec_mfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
 }
 
 /* MTC1 */
-fastcall void mips64_exec_mtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
+void mips64_exec_mtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
 {
    cpu->fpu.reg[cp1_reg] = cpu->gpr[gp_reg] & 0xffffffff;
 }

--- a/stable/mips64.c
+++ b/stable/mips64.c
@@ -500,7 +500,7 @@ void mips64_trigger_trap_exception(cpu_mips_t *cpu)
 }
 
 /* Trigger IRQs */
-fastcall void mips64_trigger_irq(cpu_mips_t *cpu)
+void mips64_trigger_irq(cpu_mips_t *cpu)
 {
    if (unlikely(cpu->irq_disable)) {
       cpu->irq_pending = 0;

--- a/stable/mips64.c
+++ b/stable/mips64.c
@@ -419,7 +419,7 @@ void mips64_trigger_exception(cpu_mips_t *cpu,u_int exc_code,int bd_slot)
  * Increment count register and trigger the timer IRQ if value in compare 
  * register is the same.
  */
-fastcall void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu)
+void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu)
 {
    cpu->cp0_virt_cnt_reg++;
 

--- a/stable/mips64.h
+++ b/stable/mips64.h
@@ -308,7 +308,7 @@ enum {
 typedef struct cpu_mips cpu_mips_t;
 
 /* Memory operation function prototype */
-typedef fastcall void (*mips_memop_fn)(cpu_mips_t *cpu,m_uint64_t vaddr,
+typedef void (*mips_memop_fn)(cpu_mips_t *cpu,m_uint64_t vaddr,
                                        u_int reg);
 
 /* TLB entry definition */

--- a/stable/mips64.h
+++ b/stable/mips64.h
@@ -503,7 +503,7 @@ void mips64_trigger_exception(cpu_mips_t *cpu,u_int exc_code,int bd_slot);
  * Increment count register and trigger the timer IRQ if value in compare 
  * register is the same.
  */
-fastcall void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu);
+void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu);
 
 /* Trigger the Timer IRQ */
 fastcall void mips64_trigger_timer_irq(cpu_mips_t *cpu);

--- a/stable/mips64.h
+++ b/stable/mips64.h
@@ -357,7 +357,7 @@ struct cpu_mips {
    mips64_jit_tcb_t **exec_blk_map;
 
    /* Virtual address to physical page translation */
-   fastcall int (*translate)(cpu_mips_t *cpu,m_uint64_t vaddr,
+   int (*translate)(cpu_mips_t *cpu,m_uint64_t vaddr,
                              m_uint32_t *phys_page);
 
    /* Memory access functions */

--- a/stable/mips64.h
+++ b/stable/mips64.h
@@ -515,7 +515,7 @@ void mips64_exec_eret(cpu_mips_t *cpu);
 void mips64_exec_syscall(cpu_mips_t *cpu);
 
 /* Execute BREAK instruction */
-fastcall void mips64_exec_break(cpu_mips_t *cpu,u_int code);
+void mips64_exec_break(cpu_mips_t *cpu,u_int code);
 
 /* Trigger a Trap Exception */
 fastcall void mips64_trigger_trap_exception(cpu_mips_t *cpu);

--- a/stable/mips64.h
+++ b/stable/mips64.h
@@ -512,7 +512,7 @@ void mips64_trigger_timer_irq(cpu_mips_t *cpu);
 void mips64_exec_eret(cpu_mips_t *cpu);
 
 /* Execute SYSCALL instruction */
-fastcall void mips64_exec_syscall(cpu_mips_t *cpu);
+void mips64_exec_syscall(cpu_mips_t *cpu);
 
 /* Execute BREAK instruction */
 fastcall void mips64_exec_break(cpu_mips_t *cpu,u_int code);

--- a/stable/mips64.h
+++ b/stable/mips64.h
@@ -542,7 +542,7 @@ void mips64_exec_mfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
 void mips64_exec_mtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
 
 /* Virtual breakpoint */
-fastcall void mips64_run_breakpoint(cpu_mips_t *cpu);
+void mips64_run_breakpoint(cpu_mips_t *cpu);
 
 /* Add a virtual breakpoint */
 int mips64_add_breakpoint(cpu_gen_t *cpu,m_uint64_t pc);

--- a/stable/mips64.h
+++ b/stable/mips64.h
@@ -530,16 +530,16 @@ void mips64_set_irq(cpu_mips_t *cpu,m_uint8_t irq);
 void mips64_clear_irq(cpu_mips_t *cpu,m_uint8_t irq);
 
 /* DMFC1 */
-fastcall void mips64_exec_dmfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
+void mips64_exec_dmfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
 
 /* DMTC1 */
-fastcall void mips64_exec_dmtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
+void mips64_exec_dmtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
 
 /* MFC1 */
-fastcall void mips64_exec_mfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
+void mips64_exec_mfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
 
 /* MTC1 */
-fastcall void mips64_exec_mtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
+void mips64_exec_mtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
 
 /* Virtual breakpoint */
 fastcall void mips64_run_breakpoint(cpu_mips_t *cpu);

--- a/stable/mips64.h
+++ b/stable/mips64.h
@@ -506,7 +506,7 @@ void mips64_trigger_exception(cpu_mips_t *cpu,u_int exc_code,int bd_slot);
 void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu);
 
 /* Trigger the Timer IRQ */
-fastcall void mips64_trigger_timer_irq(cpu_mips_t *cpu);
+void mips64_trigger_timer_irq(cpu_mips_t *cpu);
 
 /* Execute ERET instruction */
 fastcall void mips64_exec_eret(cpu_mips_t *cpu);

--- a/stable/mips64.h
+++ b/stable/mips64.h
@@ -551,7 +551,7 @@ int mips64_add_breakpoint(cpu_gen_t *cpu,m_uint64_t pc);
 void mips64_remove_breakpoint(cpu_gen_t *cpu,m_uint64_t pc);
 
 /* Debugging for register-jump to address 0 */
-fastcall void mips64_debug_jr0(cpu_mips_t *cpu);
+void mips64_debug_jr0(cpu_mips_t *cpu);
 
 /* Set a register */
 void mips64_reg_set(cpu_gen_t *cpu,u_int reg,m_uint64_t val);

--- a/stable/mips64.h
+++ b/stable/mips64.h
@@ -518,7 +518,7 @@ void mips64_exec_syscall(cpu_mips_t *cpu);
 void mips64_exec_break(cpu_mips_t *cpu,u_int code);
 
 /* Trigger a Trap Exception */
-fastcall void mips64_trigger_trap_exception(cpu_mips_t *cpu);
+void mips64_trigger_trap_exception(cpu_mips_t *cpu);
 
 /* Trigger IRQs */
 fastcall void mips64_trigger_irq(cpu_mips_t *cpu);

--- a/stable/mips64.h
+++ b/stable/mips64.h
@@ -521,7 +521,7 @@ void mips64_exec_break(cpu_mips_t *cpu,u_int code);
 void mips64_trigger_trap_exception(cpu_mips_t *cpu);
 
 /* Trigger IRQs */
-fastcall void mips64_trigger_irq(cpu_mips_t *cpu);
+void mips64_trigger_irq(cpu_mips_t *cpu);
 
 /* Set an IRQ */
 void mips64_set_irq(cpu_mips_t *cpu,m_uint8_t irq);

--- a/stable/mips64.h
+++ b/stable/mips64.h
@@ -509,7 +509,7 @@ void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu);
 void mips64_trigger_timer_irq(cpu_mips_t *cpu);
 
 /* Execute ERET instruction */
-fastcall void mips64_exec_eret(cpu_mips_t *cpu);
+void mips64_exec_eret(cpu_mips_t *cpu);
 
 /* Execute SYSCALL instruction */
 fastcall void mips64_exec_syscall(cpu_mips_t *cpu);

--- a/stable/mips64_amd64_trans.c
+++ b/stable/mips64_amd64_trans.c
@@ -443,7 +443,7 @@ void mips64_emit_breakpoint(mips64_jit_tcb_t *b)
 }
 
 /* Unknown opcode handler */
-static fastcall void mips64_unknown_opcode(cpu_mips_t *cpu,m_uint32_t opcode)
+static void mips64_unknown_opcode(cpu_mips_t *cpu,m_uint32_t opcode)
 {
    printf("CPU = %p\n",cpu);
 

--- a/stable/mips64_amd64_trans.c
+++ b/stable/mips64_amd64_trans.c
@@ -418,7 +418,7 @@ static void mips64_emit_memop(mips64_jit_tcb_t *b,int op,int base,int offset,
 }
 
 /* Coprocessor Register transfert operation */
-static void mips64_emit_cp_xfr_op(mips64_jit_tcb_t *b,int rt,int rd,void *f)
+static void mips64_emit_cp_xfr_op(mips64_jit_tcb_t *b,int rt,int rd,void (*f)(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg))
 {
    /* update pc */
    mips64_set_pc(b,b->start_pc+((b->mips_trans_pos-1)<<2));

--- a/stable/mips64_amd64_trans.c
+++ b/stable/mips64_amd64_trans.c
@@ -465,7 +465,7 @@ static int mips64_emit_unknown(cpu_mips_t *cpu,mips64_jit_tcb_t *b,
 }
 
 /* Invalid delay slot handler */
-static fastcall void mips64_invalid_delay_slot(cpu_mips_t *cpu)
+static void mips64_invalid_delay_slot(cpu_mips_t *cpu)
 {
    printf("MIPS64: invalid instruction in delay slot at 0x%llx (ra=0x%llx)\n",
           cpu->pc,cpu->gpr[MIPS_GPR_RA]);

--- a/stable/mips64_cp0.c
+++ b/stable/mips64_cp0.c
@@ -600,7 +600,7 @@ static inline void mips64_cp0_exec_tlbw(cpu_mips_t *cpu,u_int index)
 }
 
 /* TLBWI: Write Indexed TLB entry */
-fastcall void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu)
+void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu)
 {
    mips64_cp0_exec_tlbw(cpu,cpu->cp0.reg[MIPS_CP0_INDEX]);
 }

--- a/stable/mips64_cp0.c
+++ b/stable/mips64_cp0.c
@@ -277,37 +277,37 @@ static inline void mips64_cp0_s1_set_reg(cpu_mips_t *cpu,u_int cp0_s1_reg,
 }
 
 /* DMFC0 */
-fastcall void mips64_cp0_exec_dmfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
+void mips64_cp0_exec_dmfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
 {
    cpu->gpr[gp_reg] = mips64_cp0_get_reg_fast(cpu,cp0_reg);
 }
 
 /* DMTC0 */
-fastcall void mips64_cp0_exec_dmtc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
+void mips64_cp0_exec_dmtc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
 {
    mips64_cp0_set_reg(cpu,cp0_reg,cpu->gpr[gp_reg]);
 }
 
 /* MFC0 */
-fastcall void mips64_cp0_exec_mfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
+void mips64_cp0_exec_mfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
 {
    cpu->gpr[gp_reg] = sign_extend(mips64_cp0_get_reg_fast(cpu,cp0_reg),32);
 }
 
 /* MTC0 */
-fastcall void mips64_cp0_exec_mtc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
+void mips64_cp0_exec_mtc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
 {
    mips64_cp0_set_reg(cpu,cp0_reg,cpu->gpr[gp_reg] & 0xffffffff);
 }
 
 /* CFC0 */
-fastcall void mips64_cp0_exec_cfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
+void mips64_cp0_exec_cfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
 {
    cpu->gpr[gp_reg] = sign_extend(mips64_cp0_s1_get_reg(cpu,cp0_reg),32);
 }
 
 /* CTC0 */
-fastcall void mips64_cp0_exec_ctc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
+void mips64_cp0_exec_ctc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
 {
    mips64_cp0_s1_set_reg(cpu,cp0_reg,cpu->gpr[gp_reg] & 0xffffffff);
 }

--- a/stable/mips64_cp0.c
+++ b/stable/mips64_cp0.c
@@ -491,7 +491,7 @@ void mips64_cp0_map_all_tlb_to_mts(cpu_mips_t *cpu)
 }
 
 /* TLBP: Probe a TLB entry */
-fastcall void mips64_cp0_exec_tlbp(cpu_mips_t *cpu)
+void mips64_cp0_exec_tlbp(cpu_mips_t *cpu)
 {
    mips_cp0_t *cp0 = &cpu->cp0;
    m_uint64_t hi_reg,asid;

--- a/stable/mips64_cp0.c
+++ b/stable/mips64_cp0.c
@@ -523,7 +523,7 @@ void mips64_cp0_exec_tlbp(cpu_mips_t *cpu)
 }
 
 /* TLBR: Read Indexed TLB entry */
-fastcall void mips64_cp0_exec_tlbr(cpu_mips_t *cpu)
+void mips64_cp0_exec_tlbr(cpu_mips_t *cpu)
 {
    mips_cp0_t *cp0 = &cpu->cp0;
    tlb_entry_t *entry;

--- a/stable/mips64_cp0.c
+++ b/stable/mips64_cp0.c
@@ -606,7 +606,7 @@ void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu)
 }
 
 /* TLBWR: Write Random TLB entry */
-fastcall void mips64_cp0_exec_tlbwr(cpu_mips_t *cpu)
+void mips64_cp0_exec_tlbwr(cpu_mips_t *cpu)
 {
    mips64_cp0_exec_tlbw(cpu,mips64_cp0_get_random_reg(cpu));
 }

--- a/stable/mips64_cp0.h
+++ b/stable/mips64_cp0.h
@@ -56,7 +56,7 @@ void mips64_cp0_exec_tlbr(cpu_mips_t *cpu);
 void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu);
 
 /* TLBWR: Write Random TLB entry */
-fastcall void mips64_cp0_exec_tlbwr(cpu_mips_t *cpu);
+void mips64_cp0_exec_tlbwr(cpu_mips_t *cpu);
 
 /* Raw dump of the TLB */
 void mips64_tlb_raw_dump(cpu_gen_t *cpu);

--- a/stable/mips64_cp0.h
+++ b/stable/mips64_cp0.h
@@ -50,7 +50,7 @@ void mips64_cp0_map_all_tlb_to_mts(cpu_mips_t *cpu);
 void mips64_cp0_exec_tlbp(cpu_mips_t *cpu);
 
 /* TLBR: Read Indexed TLB entry */
-fastcall void mips64_cp0_exec_tlbr(cpu_mips_t *cpu);
+void mips64_cp0_exec_tlbr(cpu_mips_t *cpu);
 
 /* TLBWI: Write Indexed TLB entry */
 fastcall void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu);

--- a/stable/mips64_cp0.h
+++ b/stable/mips64_cp0.h
@@ -47,7 +47,7 @@ int mips64_cp0_tlb_lookup(cpu_mips_t *cpu,m_uint64_t vaddr,mts_map_t *res);
 void mips64_cp0_map_all_tlb_to_mts(cpu_mips_t *cpu);
 
 /* TLBP: Probe a TLB entry */
-fastcall void mips64_cp0_exec_tlbp(cpu_mips_t *cpu);
+void mips64_cp0_exec_tlbp(cpu_mips_t *cpu);
 
 /* TLBR: Read Indexed TLB entry */
 fastcall void mips64_cp0_exec_tlbr(cpu_mips_t *cpu);

--- a/stable/mips64_cp0.h
+++ b/stable/mips64_cp0.h
@@ -21,24 +21,24 @@ u_int mips64_cp0_get_mode(cpu_mips_t *cpu);
 m_uint64_t mips64_cp0_get_reg(cpu_mips_t *cpu,u_int cp0_reg);
 
 /* DMFC0 */
-fastcall void mips64_cp0_exec_dmfc0(cpu_mips_t *cpu,u_int gp_reg,
+void mips64_cp0_exec_dmfc0(cpu_mips_t *cpu,u_int gp_reg,
                                     u_int cp0_reg);
 
 /* DMTC0 */
-fastcall void mips64_cp0_exec_dmtc0(cpu_mips_t *cpu,u_int gp_reg,
+void mips64_cp0_exec_dmtc0(cpu_mips_t *cpu,u_int gp_reg,
                                     u_int cp0_reg);
 
 /* MFC0 */
-fastcall void mips64_cp0_exec_mfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
+void mips64_cp0_exec_mfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
 
 /* MTC0 */
-fastcall void mips64_cp0_exec_mtc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
+void mips64_cp0_exec_mtc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
 
 /* CFC0 */
-fastcall void mips64_cp0_exec_cfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
+void mips64_cp0_exec_cfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
 
 /* CTC0 */
-fastcall void mips64_cp0_exec_ctc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
+void mips64_cp0_exec_ctc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
 
 /* TLB lookup */
 int mips64_cp0_tlb_lookup(cpu_mips_t *cpu,m_uint64_t vaddr,mts_map_t *res);

--- a/stable/mips64_cp0.h
+++ b/stable/mips64_cp0.h
@@ -53,7 +53,7 @@ void mips64_cp0_exec_tlbp(cpu_mips_t *cpu);
 void mips64_cp0_exec_tlbr(cpu_mips_t *cpu);
 
 /* TLBWI: Write Indexed TLB entry */
-fastcall void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu);
+void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu);
 
 /* TLBWR: Write Random TLB entry */
 fastcall void mips64_cp0_exec_tlbwr(cpu_mips_t *cpu);

--- a/stable/mips64_exec.c
+++ b/stable/mips64_exec.c
@@ -298,7 +298,7 @@ _Unused static forced_inline void mips64_exec_memop(cpu_mips_t *cpu,int memop,
                                             m_uint64_t vaddr,u_int dst_reg,
                                             int keep_ll_bit)
 {     
-   fastcall mips_memop_fn fn;
+   mips_memop_fn fn;
 
    if (!keep_ll_bit) cpu->ll_bit = 0;
    fn = cpu->mem_op_fn[memop];
@@ -311,7 +311,7 @@ static forced_inline void mips64_exec_memop2(cpu_mips_t *cpu,int memop,
                                              u_int dst_reg,int keep_ll_bit)
 {
    m_uint64_t vaddr = cpu->gpr[base] + sign_extend(offset,16);
-   fastcall mips_memop_fn fn;
+   mips_memop_fn fn;
       
    if (!keep_ll_bit) cpu->ll_bit = 0;
    fn = cpu->mem_op_fn[memop];

--- a/stable/mips64_exec.c
+++ b/stable/mips64_exec.c
@@ -381,7 +381,7 @@ mips64_exec_single_instruction(cpu_mips_t *cpu,mips_insn_t instruction)
 }
 
 /* Single-step execution */
-fastcall void mips64_exec_single_step(cpu_mips_t *cpu,mips_insn_t instruction)
+void mips64_exec_single_step(cpu_mips_t *cpu,mips_insn_t instruction)
 {
    int res;
 

--- a/stable/mips64_exec.c
+++ b/stable/mips64_exec.c
@@ -338,7 +338,7 @@ static forced_inline int mips64_exec_fetch(cpu_mips_t *cpu,m_uint64_t pc,
 }
 
 /* Unknown opcode */
-static fastcall int mips64_exec_unknown(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_unknown(cpu_mips_t *cpu,mips_insn_t insn)
 {
    printf("MIPS64: unknown opcode 0x%8.8x at pc = 0x%llx\n",insn,cpu->pc);
    mips64_dump_regs(cpu->gen);
@@ -349,7 +349,7 @@ static fastcall int mips64_exec_unknown(cpu_mips_t *cpu,mips_insn_t insn)
 static forced_inline int 
 mips64_exec_single_instruction(cpu_mips_t *cpu,mips_insn_t instruction)
 {
-   register fastcall int (*exec)(cpu_mips_t *,mips_insn_t) = NULL;
+   register int (*exec)(cpu_mips_t *,mips_insn_t) = NULL;
    struct mips64_insn_exec_tag *tag;
    int index;
 
@@ -495,7 +495,7 @@ static forced_inline void mips64_exec_bdslot(cpu_mips_t *cpu)
 }
 
 /* ADD */
-static fastcall int mips64_exec_ADD(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ADD(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -509,7 +509,7 @@ static fastcall int mips64_exec_ADD(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* ADDI */
-static fastcall int mips64_exec_ADDI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ADDI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -523,7 +523,7 @@ static fastcall int mips64_exec_ADDI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* ADDIU */
-static fastcall int mips64_exec_ADDIU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ADDIU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -536,7 +536,7 @@ static fastcall int mips64_exec_ADDIU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* ADDU */
-static fastcall int mips64_exec_ADDU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ADDU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -549,7 +549,7 @@ static fastcall int mips64_exec_ADDU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* AND */
-static fastcall int mips64_exec_AND(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_AND(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -560,7 +560,7 @@ static fastcall int mips64_exec_AND(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* ANDI */
-static fastcall int mips64_exec_ANDI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ANDI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs  = bits(insn,21,25);
    int rt  = bits(insn,16,20);
@@ -571,7 +571,7 @@ static fastcall int mips64_exec_ANDI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* B (Branch, virtual instruction) */
-static fastcall int mips64_exec_B(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_B(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int offset = bits(insn,0,15);
    m_uint64_t new_pc;
@@ -588,7 +588,7 @@ static fastcall int mips64_exec_B(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BAL (Branch And Link, virtual instruction) */
-static fastcall int mips64_exec_BAL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BAL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int offset = bits(insn,0,15);
    m_uint64_t new_pc;
@@ -608,7 +608,7 @@ static fastcall int mips64_exec_BAL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BEQ (Branch On Equal) */
-static fastcall int mips64_exec_BEQ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BEQ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -635,7 +635,7 @@ static fastcall int mips64_exec_BEQ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BEQL (Branch On Equal Likely) */
-static fastcall int mips64_exec_BEQL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BEQL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -660,7 +660,7 @@ static fastcall int mips64_exec_BEQL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BEQZ (Branch On Equal Zero) - Virtual Instruction */
-static fastcall int mips64_exec_BEQZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BEQZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -686,7 +686,7 @@ static fastcall int mips64_exec_BEQZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BNEZ (Branch On Not Equal Zero) - Virtual Instruction */
-static fastcall int mips64_exec_BNEZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BNEZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -712,7 +712,7 @@ static fastcall int mips64_exec_BNEZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BGEZ (Branch On Greater or Equal Than Zero) */
-static fastcall int mips64_exec_BGEZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BGEZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -738,7 +738,7 @@ static fastcall int mips64_exec_BGEZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BGEZAL (Branch On Greater or Equal Than Zero And Link) */
-static fastcall int mips64_exec_BGEZAL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BGEZAL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -767,7 +767,7 @@ static fastcall int mips64_exec_BGEZAL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BGEZALL (Branch On Greater or Equal Than Zero And Link Likely) */
-static fastcall int mips64_exec_BGEZALL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BGEZALL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -794,7 +794,7 @@ static fastcall int mips64_exec_BGEZALL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BGEZL (Branch On Greater or Equal Than Zero Likely) */
-static fastcall int mips64_exec_BGEZL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BGEZL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -818,7 +818,7 @@ static fastcall int mips64_exec_BGEZL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BGTZ (Branch On Greater Than Zero) */
-static fastcall int mips64_exec_BGTZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BGTZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -844,7 +844,7 @@ static fastcall int mips64_exec_BGTZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BGTZL (Branch On Greater Than Zero Likely) */
-static fastcall int mips64_exec_BGTZL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BGTZL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -868,7 +868,7 @@ static fastcall int mips64_exec_BGTZL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BLEZ (Branch On Less or Equal Than Zero) */
-static fastcall int mips64_exec_BLEZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BLEZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -894,7 +894,7 @@ static fastcall int mips64_exec_BLEZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BLEZL (Branch On Less or Equal Than Zero Likely) */
-static fastcall int mips64_exec_BLEZL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BLEZL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -918,7 +918,7 @@ static fastcall int mips64_exec_BLEZL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BLTZ (Branch On Less Than Zero) */
-static fastcall int mips64_exec_BLTZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BLTZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -944,7 +944,7 @@ static fastcall int mips64_exec_BLTZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BLTZAL (Branch On Less Than Zero And Link) */
-static fastcall int mips64_exec_BLTZAL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BLTZAL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -973,7 +973,7 @@ static fastcall int mips64_exec_BLTZAL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BLTZALL (Branch On Less Than Zero And Link Likely) */
-static fastcall int mips64_exec_BLTZALL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BLTZALL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -1000,7 +1000,7 @@ static fastcall int mips64_exec_BLTZALL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BLTZL (Branch On Less Than Zero Likely) */
-static fastcall int mips64_exec_BLTZL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BLTZL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -1024,7 +1024,7 @@ static fastcall int mips64_exec_BLTZL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BNE (Branch On Not Equal) */
-static fastcall int mips64_exec_BNE(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BNE(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1051,7 +1051,7 @@ static fastcall int mips64_exec_BNE(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BNEL (Branch On Not Equal Likely) */
-static fastcall int mips64_exec_BNEL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BNEL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1076,7 +1076,7 @@ static fastcall int mips64_exec_BNEL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BREAK */
-static fastcall int mips64_exec_BREAK(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BREAK(cpu_mips_t *cpu,mips_insn_t insn)
 {
    u_int code = bits(insn,6,25);
 
@@ -1085,7 +1085,7 @@ static fastcall int mips64_exec_BREAK(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* CACHE */
-static fastcall int mips64_exec_CACHE(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_CACHE(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int op     = bits(insn,16,20);
@@ -1096,7 +1096,7 @@ static fastcall int mips64_exec_CACHE(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* CFC0 */
-static fastcall int mips64_exec_CFC0(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_CFC0(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1106,7 +1106,7 @@ static fastcall int mips64_exec_CFC0(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* CTC0 */
-static fastcall int mips64_exec_CTC0(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_CTC0(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1116,7 +1116,7 @@ static fastcall int mips64_exec_CTC0(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DADDIU */
-static fastcall int mips64_exec_DADDIU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DADDIU(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rs  = bits(insn,21,25);
    int rt  = bits(insn,16,20);
@@ -1128,7 +1128,7 @@ static fastcall int mips64_exec_DADDIU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DADDU: rd = rs + rt */
-static fastcall int mips64_exec_DADDU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DADDU(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1139,7 +1139,7 @@ static fastcall int mips64_exec_DADDU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DIV */
-static fastcall int mips64_exec_DIV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DIV(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1153,7 +1153,7 @@ static fastcall int mips64_exec_DIV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DIVU */
-static fastcall int mips64_exec_DIVU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DIVU(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1170,7 +1170,7 @@ static fastcall int mips64_exec_DIVU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DMFC0 */
-static fastcall int mips64_exec_DMFC0(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DMFC0(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1180,7 +1180,7 @@ static fastcall int mips64_exec_DMFC0(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DMFC1 */
-static fastcall int mips64_exec_DMFC1(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DMFC1(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1190,7 +1190,7 @@ static fastcall int mips64_exec_DMFC1(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DMTC0 */
-static fastcall int mips64_exec_DMTC0(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DMTC0(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1200,7 +1200,7 @@ static fastcall int mips64_exec_DMTC0(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DMTC1 */
-static fastcall int mips64_exec_DMTC1(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DMTC1(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1210,7 +1210,7 @@ static fastcall int mips64_exec_DMTC1(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSLL */
-static fastcall int mips64_exec_DSLL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSLL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1221,7 +1221,7 @@ static fastcall int mips64_exec_DSLL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSLL32 */
-static fastcall int mips64_exec_DSLL32(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSLL32(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1232,7 +1232,7 @@ static fastcall int mips64_exec_DSLL32(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSLLV */
-static fastcall int mips64_exec_DSLLV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSLLV(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1243,7 +1243,7 @@ static fastcall int mips64_exec_DSLLV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSRA */
-static fastcall int mips64_exec_DSRA(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSRA(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1254,7 +1254,7 @@ static fastcall int mips64_exec_DSRA(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSRA32 */
-static fastcall int mips64_exec_DSRA32(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSRA32(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1265,7 +1265,7 @@ static fastcall int mips64_exec_DSRA32(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSRAV */
-static fastcall int mips64_exec_DSRAV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSRAV(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1276,7 +1276,7 @@ static fastcall int mips64_exec_DSRAV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSRL */
-static fastcall int mips64_exec_DSRL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSRL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1287,7 +1287,7 @@ static fastcall int mips64_exec_DSRL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSRL32 */
-static fastcall int mips64_exec_DSRL32(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSRL32(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1298,7 +1298,7 @@ static fastcall int mips64_exec_DSRL32(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSRLV */
-static fastcall int mips64_exec_DSRLV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSRLV(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1309,7 +1309,7 @@ static fastcall int mips64_exec_DSRLV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSUBU */
-static fastcall int mips64_exec_DSUBU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSUBU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1320,14 +1320,14 @@ static fastcall int mips64_exec_DSUBU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* ERET */
-static fastcall int mips64_exec_ERET(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ERET(cpu_mips_t *cpu,mips_insn_t insn)
 {
    mips64_exec_eret(cpu);
    return(1);
 }
 
 /* J */
-static fastcall int mips64_exec_J(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_J(cpu_mips_t *cpu,mips_insn_t insn)
 {
    u_int instr_index = bits(insn,0,25);
    m_uint64_t new_pc;
@@ -1345,7 +1345,7 @@ static fastcall int mips64_exec_J(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* JAL */
-static fastcall int mips64_exec_JAL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_JAL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    u_int instr_index = bits(insn,0,25);
    m_uint64_t new_pc;
@@ -1366,7 +1366,7 @@ static fastcall int mips64_exec_JAL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* JALR */
-static fastcall int mips64_exec_JALR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_JALR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rd = bits(insn,11,15);
@@ -1387,7 +1387,7 @@ static fastcall int mips64_exec_JALR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* JR */
-static fastcall int mips64_exec_JR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_JR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    m_uint64_t new_pc;
@@ -1404,7 +1404,7 @@ static fastcall int mips64_exec_JR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LB (Load Byte) */
-static fastcall int mips64_exec_LB(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LB(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1415,7 +1415,7 @@ static fastcall int mips64_exec_LB(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LBU (Load Byte Unsigned) */
-static fastcall int mips64_exec_LBU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LBU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1426,7 +1426,7 @@ static fastcall int mips64_exec_LBU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LD (Load Double-Word) */
-static fastcall int mips64_exec_LD(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LD(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1437,7 +1437,7 @@ static fastcall int mips64_exec_LD(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LDC1 (Load Double-Word to Coprocessor 1) */
-static fastcall int mips64_exec_LDC1(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LDC1(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int ft     = bits(insn,16,20);
@@ -1448,7 +1448,7 @@ static fastcall int mips64_exec_LDC1(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LDL (Load Double-Word Left) */
-static fastcall int mips64_exec_LDL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LDL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1459,7 +1459,7 @@ static fastcall int mips64_exec_LDL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LDR (Load Double-Word Right) */
-static fastcall int mips64_exec_LDR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LDR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1470,7 +1470,7 @@ static fastcall int mips64_exec_LDR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LH (Load Half-Word) */
-static fastcall int mips64_exec_LH(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LH(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1481,7 +1481,7 @@ static fastcall int mips64_exec_LH(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LHU (Load Half-Word Unsigned) */
-static fastcall int mips64_exec_LHU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LHU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1492,7 +1492,7 @@ static fastcall int mips64_exec_LHU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LI (virtual) */
-static fastcall int mips64_exec_LI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt  = bits(insn,16,20);
    int imm = bits(insn,0,15);
@@ -1502,7 +1502,7 @@ static fastcall int mips64_exec_LI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LL (Load Linked) */
-static fastcall int mips64_exec_LL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1513,7 +1513,7 @@ static fastcall int mips64_exec_LL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LUI */
-static fastcall int mips64_exec_LUI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LUI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt  = bits(insn,16,20);
    int imm = bits(insn,0,15);
@@ -1523,7 +1523,7 @@ static fastcall int mips64_exec_LUI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LW (Load Word) */
-static fastcall int mips64_exec_LW(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LW(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1534,7 +1534,7 @@ static fastcall int mips64_exec_LW(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LWL (Load Word Left) */
-static fastcall int mips64_exec_LWL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LWL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1545,7 +1545,7 @@ static fastcall int mips64_exec_LWL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LWR (Load Word Right) */
-static fastcall int mips64_exec_LWR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LWR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1556,7 +1556,7 @@ static fastcall int mips64_exec_LWR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LWU (Load Word Unsigned) */
-static fastcall int mips64_exec_LWU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LWU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1567,7 +1567,7 @@ static fastcall int mips64_exec_LWU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MFC0 */
-static fastcall int mips64_exec_MFC0(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MFC0(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1577,7 +1577,7 @@ static fastcall int mips64_exec_MFC0(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MFC1 */
-static fastcall int mips64_exec_MFC1(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MFC1(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1587,7 +1587,7 @@ static fastcall int mips64_exec_MFC1(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MFHI */
-static fastcall int mips64_exec_MFHI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MFHI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rd = bits(insn,11,15);
 
@@ -1596,7 +1596,7 @@ static fastcall int mips64_exec_MFHI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MFLO */
-static fastcall int mips64_exec_MFLO(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MFLO(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rd = bits(insn,11,15);
 
@@ -1605,7 +1605,7 @@ static fastcall int mips64_exec_MFLO(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MOVE (virtual instruction, real: ADDU) */
-static fastcall int mips64_exec_MOVE(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MOVE(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rd = bits(insn,11,15);
@@ -1615,7 +1615,7 @@ static fastcall int mips64_exec_MOVE(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MTC0 */
-static fastcall int mips64_exec_MTC0(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MTC0(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1625,7 +1625,7 @@ static fastcall int mips64_exec_MTC0(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MTC1 */
-static fastcall int mips64_exec_MTC1(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MTC1(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1635,7 +1635,7 @@ static fastcall int mips64_exec_MTC1(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MTHI */
-static fastcall int mips64_exec_MTHI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MTHI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
 
@@ -1644,7 +1644,7 @@ static fastcall int mips64_exec_MTHI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MTLO */
-static fastcall int mips64_exec_MTLO(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MTLO(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
 
@@ -1653,7 +1653,7 @@ static fastcall int mips64_exec_MTLO(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MUL */
-static fastcall int mips64_exec_MUL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MUL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1667,7 +1667,7 @@ static fastcall int mips64_exec_MUL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MULT */
-static fastcall int mips64_exec_MULT(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MULT(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1682,7 +1682,7 @@ static fastcall int mips64_exec_MULT(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MULTU */
-static fastcall int mips64_exec_MULTU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MULTU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1696,13 +1696,13 @@ static fastcall int mips64_exec_MULTU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* NOP */
-static fastcall int mips64_exec_NOP(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_NOP(cpu_mips_t *cpu,mips_insn_t insn)
 {
    return(0);
 }
 
 /* NOR */
-static fastcall int mips64_exec_NOR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_NOR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1713,7 +1713,7 @@ static fastcall int mips64_exec_NOR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* OR */
-static fastcall int mips64_exec_OR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_OR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1724,7 +1724,7 @@ static fastcall int mips64_exec_OR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* ORI */
-static fastcall int mips64_exec_ORI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ORI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs  = bits(insn,21,25);
    int rt  = bits(insn,16,20);
@@ -1735,19 +1735,19 @@ static fastcall int mips64_exec_ORI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* PREF */
-static fastcall int mips64_exec_PREF(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_PREF(cpu_mips_t *cpu,mips_insn_t insn)
 {
    return(0);
 }
 
 /* PREFI */
-static fastcall int mips64_exec_PREFI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_PREFI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    return(0);
 }
 
 /* SB (Store Byte) */
-static fastcall int mips64_exec_SB(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SB(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1758,7 +1758,7 @@ static fastcall int mips64_exec_SB(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SC (Store Conditional) */
-static fastcall int mips64_exec_SC(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SC(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1769,7 +1769,7 @@ static fastcall int mips64_exec_SC(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SD (Store Double-Word) */
-static fastcall int mips64_exec_SD(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SD(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1780,7 +1780,7 @@ static fastcall int mips64_exec_SD(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SDL (Store Double-Word Left) */
-static fastcall int mips64_exec_SDL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SDL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1791,7 +1791,7 @@ static fastcall int mips64_exec_SDL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SDR (Store Double-Word Right) */
-static fastcall int mips64_exec_SDR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SDR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1802,7 +1802,7 @@ static fastcall int mips64_exec_SDR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SDC1 (Store Double-Word from Coprocessor 1) */
-static fastcall int mips64_exec_SDC1(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SDC1(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int ft     = bits(insn,16,20);
@@ -1813,7 +1813,7 @@ static fastcall int mips64_exec_SDC1(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SH (Store Half-Word) */
-static fastcall int mips64_exec_SH(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SH(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1824,7 +1824,7 @@ static fastcall int mips64_exec_SH(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SLL */
-static fastcall int mips64_exec_SLL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SLL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1837,7 +1837,7 @@ static fastcall int mips64_exec_SLL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SLLV */
-static fastcall int mips64_exec_SLLV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SLLV(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1850,7 +1850,7 @@ static fastcall int mips64_exec_SLLV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SLT */
-static fastcall int mips64_exec_SLT(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SLT(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1865,7 +1865,7 @@ static fastcall int mips64_exec_SLT(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SLTI */
-static fastcall int mips64_exec_SLTI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SLTI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1881,7 +1881,7 @@ static fastcall int mips64_exec_SLTI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SLTIU */
-static fastcall int mips64_exec_SLTIU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SLTIU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1897,7 +1897,7 @@ static fastcall int mips64_exec_SLTIU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SLTU */
-static fastcall int mips64_exec_SLTU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SLTU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1912,7 +1912,7 @@ static fastcall int mips64_exec_SLTU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SRA */
-static fastcall int mips64_exec_SRA(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SRA(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1925,7 +1925,7 @@ static fastcall int mips64_exec_SRA(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SRAV */
-static fastcall int mips64_exec_SRAV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SRAV(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1938,7 +1938,7 @@ static fastcall int mips64_exec_SRAV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SRL */
-static fastcall int mips64_exec_SRL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SRL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1951,7 +1951,7 @@ static fastcall int mips64_exec_SRL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SRLV */
-static fastcall int mips64_exec_SRLV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SRLV(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1964,7 +1964,7 @@ static fastcall int mips64_exec_SRLV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SUB */
-static fastcall int mips64_exec_SUB(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SUB(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1978,7 +1978,7 @@ static fastcall int mips64_exec_SUB(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SUBU */
-static fastcall int mips64_exec_SUBU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SUBU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1991,7 +1991,7 @@ static fastcall int mips64_exec_SUBU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SW (Store Word) */
-static fastcall int mips64_exec_SW(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SW(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -2002,7 +2002,7 @@ static fastcall int mips64_exec_SW(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SWL (Store Word Left) */
-static fastcall int mips64_exec_SWL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SWL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -2013,7 +2013,7 @@ static fastcall int mips64_exec_SWL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SWR (Store Word Right) */
-static fastcall int mips64_exec_SWR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SWR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -2024,20 +2024,20 @@ static fastcall int mips64_exec_SWR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SYNC */
-static fastcall int mips64_exec_SYNC(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SYNC(cpu_mips_t *cpu,mips_insn_t insn)
 {
    return(0);
 }
 
 /* SYSCALL */
-static fastcall int mips64_exec_SYSCALL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SYSCALL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    mips64_exec_syscall(cpu);
    return(1);
 }
 
 /* TEQ (Trap if Equal) */
-static fastcall int mips64_exec_TEQ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_TEQ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -2051,7 +2051,7 @@ static fastcall int mips64_exec_TEQ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* TEQI (Trap if Equal Immediate) */
-static fastcall int mips64_exec_TEQI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_TEQI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int imm = bits(insn,0,15);
@@ -2066,35 +2066,35 @@ static fastcall int mips64_exec_TEQI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* TLBP */
-static fastcall int mips64_exec_TLBP(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_TLBP(cpu_mips_t *cpu,mips_insn_t insn)
 {
    mips64_cp0_exec_tlbp(cpu);
    return(0);
 }
 
 /* TLBR */
-static fastcall int mips64_exec_TLBR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_TLBR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    mips64_cp0_exec_tlbr(cpu);
    return(0);
 }
 
 /* TLBWI */
-static fastcall int mips64_exec_TLBWI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_TLBWI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    mips64_cp0_exec_tlbwi(cpu);
    return(0);
 }
 
 /* TLBWR */
-static fastcall int mips64_exec_TLBWR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_TLBWR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    mips64_cp0_exec_tlbwr(cpu);
    return(0);
 }
 
 /* XOR */
-static fastcall int mips64_exec_XOR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_XOR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -2105,7 +2105,7 @@ static fastcall int mips64_exec_XOR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* XORI */
-static fastcall int mips64_exec_XORI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_XORI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs  = bits(insn,21,25);
    int rt  = bits(insn,16,20);

--- a/stable/mips64_exec.h
+++ b/stable/mips64_exec.h
@@ -33,7 +33,7 @@ void mips64_dump_insn_block(cpu_mips_t *cpu,m_uint64_t pc,u_int count,
                             size_t insn_name_size);
 
 /* Single-step execution */
-fastcall void mips64_exec_single_step(cpu_mips_t *cpu,mips_insn_t instruction);
+void mips64_exec_single_step(cpu_mips_t *cpu,mips_insn_t instruction);
 
 /* Run MIPS code in step-by-step mode */
 void *mips64_exec_run_cpu(cpu_gen_t *cpu);

--- a/stable/mips64_exec.h
+++ b/stable/mips64_exec.h
@@ -11,7 +11,7 @@
 /* MIPS instruction recognition */
 struct mips64_insn_exec_tag {
    char *name;
-   fastcall int (*exec)(cpu_mips_t *,mips_insn_t);
+   int (*exec)(cpu_mips_t *,mips_insn_t);
    m_uint32_t mask,value;
    int delay_slot;
    int instr_type;

--- a/stable/mips64_mem.c
+++ b/stable/mips64_mem.c
@@ -295,7 +295,7 @@ void *mips64_mts64_access(cpu_mips_t *cpu,m_uint64_t vaddr,
 }
 
 /* MTS64 virtual address to physical page translation */
-static fastcall int mips64_mts64_translate(cpu_mips_t *cpu,m_uint64_t vaddr,
+static int mips64_mts64_translate(cpu_mips_t *cpu,m_uint64_t vaddr,
                                            m_uint32_t *phys_page)
 {   
    mts64_entry_t *entry,alt_entry;
@@ -449,7 +449,7 @@ void *mips64_mts32_access(cpu_mips_t *cpu,m_uint64_t vaddr,
 }
 
 /* MTS32 virtual address to physical page translation */
-static fastcall int mips64_mts32_translate(cpu_mips_t *cpu,m_uint64_t vaddr,
+static int mips64_mts32_translate(cpu_mips_t *cpu,m_uint64_t vaddr,
                                            m_uint32_t *phys_page)
 {     
    mts32_entry_t *entry,alt_entry;

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -487,8 +487,9 @@ static void mips64_emit_cp_xfr_op(mips64_jit_tcb_t *b,int rt,int rd,void (*f)(cp
 /* Virtual Breakpoint */
 void mips64_emit_breakpoint(mips64_jit_tcb_t *b)
 {
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_c_call(b,mips64_run_breakpoint);
    x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
 }

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -1396,9 +1396,11 @@ DECLARE_INSN(BREAK)
 {	
    u_int code = bits(insn,6,25);
 
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_mov_reg_imm(b->jit_ptr,X86_EDX,code);
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,4);
+   x86_push_reg(b->jit_ptr,X86_EDX);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_exec_break);
    x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
 

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -2892,7 +2892,10 @@ DECLARE_INSN(TLBWR)
 {   
    mips64_set_pc(b,b->start_pc+((b->mips_trans_pos-1)<<2));
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_cp0_exec_tlbwr);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    return(0);
 }
 

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -485,7 +485,7 @@ void mips64_emit_breakpoint(mips64_jit_tcb_t *b)
 }
 
 /* Unknown opcode handler */
-static asmlinkage void mips64_unknown_opcode(cpu_mips_t *cpu,m_uint32_t opcode)
+static void mips64_unknown_opcode(cpu_mips_t *cpu,m_uint32_t opcode)
 {
    printf("MIPS64: unhandled opcode 0x%8.8x at 0x%llx (ra=0x%llx)\n",
           opcode,cpu->pc,cpu->gpr[MIPS_GPR_RA]);

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -195,7 +195,11 @@ void mips64_emit_single_step(mips64_jit_tcb_t *b,mips_insn_t insn)
 {
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
    x86_mov_reg_imm(b->jit_ptr,X86_EDX,insn);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,4);
+   x86_push_reg(b->jit_ptr,X86_EDX);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_exec_single_step);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
 }
 
 /* Fast memory operation prototype */

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -507,7 +507,7 @@ static int mips64_emit_unknown(cpu_mips_t *cpu,mips64_jit_tcb_t *b,
 }
 
 /* Invalid delay slot handler */
-static fastcall void mips64_invalid_delay_slot(cpu_mips_t *cpu)
+static void mips64_invalid_delay_slot(cpu_mips_t *cpu)
 {
    printf("MIPS64: invalid instruction in delay slot at 0x%llx (ra=0x%llx)\n",
           cpu->pc,cpu->gpr[MIPS_GPR_RA]);
@@ -521,8 +521,9 @@ static fastcall void mips64_invalid_delay_slot(cpu_mips_t *cpu)
 /* Emit unhandled instruction code */
 int mips64_emit_invalid_delay_slot(mips64_jit_tcb_t *b)
 {   
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_c_call(b,mips64_invalid_delay_slot);
    x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -2880,7 +2880,10 @@ DECLARE_INSN(TLBWI)
 {   
    mips64_set_pc(b,b->start_pc+((b->mips_trans_pos-1)<<2));
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_cp0_exec_tlbwi);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    return(0);
 }
 

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -2809,8 +2809,9 @@ DECLARE_INSN(TEQ)
    x86_branch8(b->jit_ptr, X86_CC_NE, 0, 1);
 
    /* Generate trap exception */
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_c_call(b,mips64_trigger_trap_exception);
    x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    
@@ -2846,8 +2847,9 @@ DECLARE_INSN(TEQI)
    x86_branch8(b->jit_ptr, X86_CC_NE, 0, 1);
 
    /* Generate trap exception */
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_c_call(b,mips64_trigger_trap_exception);
    x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
 

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -300,14 +300,14 @@ static void mips64_emit_memop_fast64(mips64_jit_tcb_t *b,int write_op,
    /* EAX = CPU instance pointer */
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
 
-   /* 
-    * Push parameters on stack and call memory function.
-    * Keep the stack aligned on a 16-byte boundary for Darwin/x86.
-    */
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   /* Call memory function */
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_push_reg(b->jit_ptr,X86_EBX);
+   x86_push_reg(b->jit_ptr,X86_ECX);
+   x86_push_reg(b->jit_ptr,X86_EDX);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    x86_call_membase(b->jit_ptr,X86_EDI,MEMOP_OFFSET(opcode));
-   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12+16);
 
    x86_patch(p_exit,b->jit_ptr);
 }
@@ -388,14 +388,14 @@ static void mips64_emit_memop_fast32(mips64_jit_tcb_t *b,int write_op,
    /* EAX = CPU instance pointer */
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
 
-   /* 
-    * Push parameters on stack and call memory function.
-    * Keep the stack aligned on a 16-byte boundary for Darwin/x86.
-    */
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   /* Call memory function */
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_push_reg(b->jit_ptr,X86_EBX);
+   x86_push_reg(b->jit_ptr,X86_ECX);
+   x86_push_reg(b->jit_ptr,X86_EDX);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    x86_call_membase(b->jit_ptr,X86_EDI,MEMOP_OFFSET(opcode));
-   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12+16);
 
    x86_patch(p_exit,b->jit_ptr);
 }
@@ -447,14 +447,14 @@ static void mips64_emit_memop(mips64_jit_tcb_t *b,int op,int base,int offset,
    /* EAX = CPU instance pointer */
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
 
-   /* 
-    * Push parameters on stack and call memory function.
-    * Keep the stack aligned on a 16-byte boundary for Darwin/x86.
-    */
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   /* Call memory function */
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_push_reg(b->jit_ptr,X86_EBX);
+   x86_push_reg(b->jit_ptr,X86_ECX);
+   x86_push_reg(b->jit_ptr,X86_EDX);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    x86_call_membase(b->jit_ptr,X86_EDI,MEMOP_OFFSET(op));
-   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12+16);
 }
 
 /* Coprocessor Register transfert operation */

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -566,7 +566,10 @@ void mips64_check_pending_irq(mips64_jit_tcb_t *b)
 
    /* Trigger the IRQ */
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_trigger_irq);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    mips64_jit_tcb_push_epilog(b);
 
    x86_patch(test1,b->jit_ptr);

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -1769,7 +1769,10 @@ DECLARE_INSN(ERET)
    mips64_set_pc(b,b->start_pc+((b->mips_trans_pos-1)<<2));
 
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_exec_eret);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    mips64_jit_tcb_push_epilog(b);
    return(0);
 }

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -2778,7 +2778,10 @@ DECLARE_INSN(SYSCALL)
    mips64_set_pc(b,b->start_pc+((b->mips_trans_pos-1)<<2));
 
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_exec_syscall);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
 
    mips64_jit_tcb_push_epilog(b);
    return(0);

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -2856,7 +2856,10 @@ DECLARE_INSN(TLBP)
 {
    mips64_set_pc(b,b->start_pc+((b->mips_trans_pos-1)<<2));
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_cp0_exec_tlbp);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    return(0);
 }
 

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -462,7 +462,7 @@ static void mips64_emit_memop(mips64_jit_tcb_t *b,int op,int base,int offset,
 }
 
 /* Coprocessor Register transfert operation */
-static void mips64_emit_cp_xfr_op(mips64_jit_tcb_t *b,int rt,int rd,void *f)
+static void mips64_emit_cp_xfr_op(mips64_jit_tcb_t *b,int rt,int rd,void (*f)(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg))
 {
    /* update pc */
    mips64_set_pc(b,b->start_pc+((b->mips_trans_pos-1)<<2));
@@ -476,7 +476,12 @@ static void mips64_emit_cp_xfr_op(mips64_jit_tcb_t *b,int rt,int rd,void *f)
    /* cpu instance */
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
 
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,0);
+   x86_push_reg(b->jit_ptr,X86_ECX);
+   x86_push_reg(b->jit_ptr,X86_EDX);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,f);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
 }
 
 /* Virtual Breakpoint */

--- a/stable/mips64_x86_trans.c
+++ b/stable/mips64_x86_trans.c
@@ -2868,7 +2868,10 @@ DECLARE_INSN(TLBR)
 {  
    mips64_set_pc(b,b->start_pc+((b->mips_trans_pos-1)<<2));
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_cp0_exec_tlbr);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    return(0);
 }
 

--- a/stable/mips_mts.c
+++ b/stable/mips_mts.c
@@ -13,7 +13,7 @@ static forced_inline void *MTS_PROTO(access)(cpu_mips_t *cpu,m_uint64_t vaddr,
                                              u_int op_code,u_int op_size,
                                              u_int op_type,m_uint64_t *data);
 
-static fastcall int MTS_PROTO(translate)(cpu_mips_t *cpu,m_uint64_t vaddr,
+static int MTS_PROTO(translate)(cpu_mips_t *cpu,m_uint64_t vaddr,
                                          m_uint32_t *phys_page);
 
 /* Initialize the MTS subsystem for the specified CPU */

--- a/stable/mips_mts.c
+++ b/stable/mips_mts.c
@@ -143,7 +143,7 @@ static void *MTS_PROTO(lookup)(cpu_mips_t *cpu,m_uint64_t vaddr)
 
 /* LB: Load Byte */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(lb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -155,7 +155,7 @@ fastcall void MTS_PROTO(lb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* LBU: Load Byte Unsigned */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(lbu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lbu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -167,7 +167,7 @@ fastcall void MTS_PROTO(lbu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* LH: Load Half-Word */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(lh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -179,7 +179,7 @@ fastcall void MTS_PROTO(lh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* LHU: Load Half-Word Unsigned */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(lhu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lhu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -191,7 +191,7 @@ fastcall void MTS_PROTO(lhu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* LW: Load Word */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(lw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -203,7 +203,7 @@ fastcall void MTS_PROTO(lw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* LWU: Load Word Unsigned */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(lwu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lwu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -215,7 +215,7 @@ fastcall void MTS_PROTO(lwu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* LD: Load Double-Word */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(ld)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(ld)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -227,7 +227,7 @@ fastcall void MTS_PROTO(ld)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* SB: Store Byte */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(sb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -239,7 +239,7 @@ fastcall void MTS_PROTO(sb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* SH: Store Half-Word */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(sh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -251,7 +251,7 @@ fastcall void MTS_PROTO(sh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* SW: Store Word */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(sw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -263,7 +263,7 @@ fastcall void MTS_PROTO(sw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* SD: Store Double-Word */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(sd)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sd)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -275,7 +275,7 @@ fastcall void MTS_PROTO(sd)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* LDC1: Load Double-Word To Coprocessor 1 */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(ldc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(ldc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -287,7 +287,7 @@ fastcall void MTS_PROTO(ldc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* LWL: Load Word Left */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(lwl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lwl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
    m_uint64_t data;
@@ -311,7 +311,7 @@ fastcall void MTS_PROTO(lwl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* LWR: Load Word Right */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(lwr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lwr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
    m_uint64_t data;
@@ -336,7 +336,7 @@ fastcall void MTS_PROTO(lwr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* LDL: Load Double-Word Left */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(ldl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(ldl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
    m_uint64_t data;
@@ -359,7 +359,7 @@ fastcall void MTS_PROTO(ldl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* LDR: Load Double-Word Right */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(ldr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(ldr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
    m_uint64_t data;
@@ -382,7 +382,7 @@ fastcall void MTS_PROTO(ldr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* SWL: Store Word Left */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(swl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(swl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
    m_uint64_t data;
@@ -407,7 +407,7 @@ fastcall void MTS_PROTO(swl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* SWR: Store Word Right */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(swr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(swr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
    m_uint64_t data;
@@ -432,7 +432,7 @@ fastcall void MTS_PROTO(swr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* SDL: Store Double-Word Left */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(sdl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sdl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
    m_uint64_t data;
@@ -457,7 +457,7 @@ fastcall void MTS_PROTO(sdl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* SDR: Store Double-Word Right */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(sdr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sdr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
    m_uint64_t data;
@@ -482,7 +482,7 @@ fastcall void MTS_PROTO(sdr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* LL: Load Linked */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(ll)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(ll)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -496,7 +496,7 @@ fastcall void MTS_PROTO(ll)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* SC: Store Conditional */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(sc)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sc)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -512,7 +512,7 @@ fastcall void MTS_PROTO(sc)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* SDC1: Store Double-Word from Coprocessor 1 */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(sdc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sdc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -524,7 +524,7 @@ fastcall void MTS_PROTO(sdc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 
 /* CACHE: Cache operation */
 __attribute__((force_align_arg_pointer))
-fastcall void MTS_PROTO(cache)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int op)
+void MTS_PROTO(cache)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int op)
 {
    mips64_jit_tcb_t *block;
    m_uint32_t pc_hash;

--- a/stable/mips_mts.c
+++ b/stable/mips_mts.c
@@ -142,7 +142,6 @@ static void *MTS_PROTO(lookup)(cpu_mips_t *cpu,m_uint64_t vaddr)
 /* === MIPS Memory Operations ============================================= */
 
 /* LB: Load Byte */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(lb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -154,7 +153,6 @@ void MTS_PROTO(lb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LBU: Load Byte Unsigned */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(lbu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -166,7 +164,6 @@ void MTS_PROTO(lbu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LH: Load Half-Word */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(lh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -178,7 +175,6 @@ void MTS_PROTO(lh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LHU: Load Half-Word Unsigned */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(lhu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -190,7 +186,6 @@ void MTS_PROTO(lhu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LW: Load Word */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(lw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -202,7 +197,6 @@ void MTS_PROTO(lw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LWU: Load Word Unsigned */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(lwu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -214,7 +208,6 @@ void MTS_PROTO(lwu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LD: Load Double-Word */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(ld)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -226,7 +219,6 @@ void MTS_PROTO(ld)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SB: Store Byte */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(sb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -238,7 +230,6 @@ void MTS_PROTO(sb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SH: Store Half-Word */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(sh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -250,7 +241,6 @@ void MTS_PROTO(sh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SW: Store Word */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(sw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -262,7 +252,6 @@ void MTS_PROTO(sw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SD: Store Double-Word */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(sd)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -274,7 +263,6 @@ void MTS_PROTO(sd)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LDC1: Load Double-Word To Coprocessor 1 */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(ldc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -286,7 +274,6 @@ void MTS_PROTO(ldc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LWL: Load Word Left */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(lwl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
@@ -310,7 +297,6 @@ void MTS_PROTO(lwl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LWR: Load Word Right */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(lwr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
@@ -335,7 +321,6 @@ void MTS_PROTO(lwr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LDL: Load Double-Word Left */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(ldl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
@@ -358,7 +343,6 @@ void MTS_PROTO(ldl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LDR: Load Double-Word Right */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(ldr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
@@ -381,7 +365,6 @@ void MTS_PROTO(ldr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SWL: Store Word Left */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(swl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
@@ -406,7 +389,6 @@ void MTS_PROTO(swl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SWR: Store Word Right */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(swr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
@@ -431,7 +413,6 @@ void MTS_PROTO(swr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SDL: Store Double-Word Left */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(sdl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
@@ -456,7 +437,6 @@ void MTS_PROTO(sdl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SDR: Store Double-Word Right */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(sdr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
@@ -481,7 +461,6 @@ void MTS_PROTO(sdr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LL: Load Linked */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(ll)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -495,7 +474,6 @@ void MTS_PROTO(ll)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SC: Store Conditional */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(sc)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -511,7 +489,6 @@ void MTS_PROTO(sc)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SDC1: Store Double-Word from Coprocessor 1 */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(sdc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -523,7 +500,6 @@ void MTS_PROTO(sdc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* CACHE: Cache operation */
-__attribute__((force_align_arg_pointer))
 void MTS_PROTO(cache)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int op)
 {
    mips64_jit_tcb_t *block;

--- a/stable/ppc32.c
+++ b/stable/ppc32.c
@@ -323,7 +323,7 @@ void ppc32_trigger_exception(cpu_ppc_t *cpu,u_int exc_vector)
 }
 
 /* Trigger IRQs */
-fastcall void ppc32_trigger_irq(cpu_ppc_t *cpu)
+void ppc32_trigger_irq(cpu_ppc_t *cpu)
 {
    if (unlikely(cpu->irq_disable)) {
       cpu->irq_pending = FALSE;

--- a/stable/ppc32.c
+++ b/stable/ppc32.c
@@ -351,7 +351,7 @@ void ppc32_trigger_timer_irq(cpu_ppc_t *cpu)
 }
 
 /* Virtual breakpoint */
-fastcall void ppc32_run_breakpoint(cpu_ppc_t *cpu)
+void ppc32_run_breakpoint(cpu_ppc_t *cpu)
 {
    cpu_log(cpu->gen,"BREAKPOINT",
            "Virtual breakpoint reached at IA=0x%8.8x\n",cpu->ia);

--- a/stable/ppc32.h
+++ b/stable/ppc32.h
@@ -250,7 +250,7 @@ enum {
 typedef struct cpu_ppc cpu_ppc_t;
 
 /* Memory operation function prototype */
-typedef fastcall void (*ppc_memop_fn)(cpu_ppc_t *cpu,m_uint32_t vaddr,
+typedef void (*ppc_memop_fn)(cpu_ppc_t *cpu,m_uint32_t vaddr,
                                       u_int reg);
 
 /* BAT type indexes */

--- a/stable/ppc32.h
+++ b/stable/ppc32.h
@@ -518,7 +518,7 @@ void ppc32_trigger_timer_irq(cpu_ppc_t *cpu);
 fastcall void ppc32_trigger_irq(cpu_ppc_t *cpu);
 
 /* Virtual breakpoint */
-fastcall void ppc32_run_breakpoint(cpu_ppc_t *cpu);
+void ppc32_run_breakpoint(cpu_ppc_t *cpu);
 
 /* Add a virtual breakpoint */
 int ppc32_add_breakpoint(cpu_gen_t *cpu,m_uint64_t ia);

--- a/stable/ppc32.h
+++ b/stable/ppc32.h
@@ -515,7 +515,7 @@ void ppc32_trigger_exception(cpu_ppc_t *cpu,u_int exc_vector);
 void ppc32_trigger_timer_irq(cpu_ppc_t *cpu);
 
 /* Trigger IRQs */
-fastcall void ppc32_trigger_irq(cpu_ppc_t *cpu);
+void ppc32_trigger_irq(cpu_ppc_t *cpu);
 
 /* Virtual breakpoint */
 void ppc32_run_breakpoint(cpu_ppc_t *cpu);

--- a/stable/ppc32.h
+++ b/stable/ppc32.h
@@ -315,7 +315,7 @@ struct cpu_ppc {
    ppc32_jit_tcb_t **exec_blk_map,**exec_phys_map;
 
    /* Virtual address to physical page translation */
-   fastcall int (*translate)(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int cid,
+   int (*translate)(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int cid,
                              m_uint32_t *phys_page);
 
    /* Memory access functions */

--- a/stable/ppc32_exec.c
+++ b/stable/ppc32_exec.c
@@ -118,7 +118,7 @@ static forced_inline int ppc32_exec_fetch(cpu_ppc_t *cpu,m_uint32_t ia,
 }
 
 /* Unknown opcode */
-static fastcall int ppc32_exec_unknown(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_unknown(cpu_ppc_t *cpu,ppc_insn_t insn)
 {   
    printf("PPC32: unknown opcode 0x%8.8x at ia = 0x%x\n",insn,cpu->ia);
    ppc32_dump_regs(cpu->gen);
@@ -129,7 +129,7 @@ static fastcall int ppc32_exec_unknown(cpu_ppc_t *cpu,ppc_insn_t insn)
 static forced_inline int 
 ppc32_exec_single_instruction(cpu_ppc_t *cpu,ppc_insn_t instruction)
 {
-   register fastcall int (*exec)(cpu_ppc_t *,ppc_insn_t) = NULL;
+   register int (*exec)(cpu_ppc_t *,ppc_insn_t) = NULL;
    struct ppc32_insn_exec_tag *tag;
    int index;
    
@@ -363,7 +363,7 @@ static forced_inline int ppc32_check_cond(cpu_ppc_t *cpu,m_uint32_t bo,
 }
 
 /* MFLR - Move From Link Register */
-static fastcall int ppc32_exec_MFLR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFLR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
 
@@ -372,7 +372,7 @@ static fastcall int ppc32_exec_MFLR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MTLR - Move To Link Register */
-static fastcall int ppc32_exec_MTLR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTLR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
 
@@ -381,7 +381,7 @@ static fastcall int ppc32_exec_MTLR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFCTR - Move From Counter Register */
-static fastcall int ppc32_exec_MFCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
 
@@ -390,7 +390,7 @@ static fastcall int ppc32_exec_MFCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MTCTR - Move To Counter Register */
-static fastcall int ppc32_exec_MTCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
 
@@ -399,7 +399,7 @@ static fastcall int ppc32_exec_MTCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADD */
-static fastcall int ppc32_exec_ADD(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADD(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -410,7 +410,7 @@ static fastcall int ppc32_exec_ADD(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADD. */
-static fastcall int ppc32_exec_ADD_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADD_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -424,7 +424,7 @@ static fastcall int ppc32_exec_ADD_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDO - Add with Overflow */
-static fastcall int ppc32_exec_ADDO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -441,7 +441,7 @@ static fastcall int ppc32_exec_ADDO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDO. */
-static fastcall int ppc32_exec_ADDO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -459,7 +459,7 @@ static fastcall int ppc32_exec_ADDO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDC - Add Carrying */
-static fastcall int ppc32_exec_ADDC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -476,7 +476,7 @@ static fastcall int ppc32_exec_ADDC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDC. */
-static fastcall int ppc32_exec_ADDC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -494,7 +494,7 @@ static fastcall int ppc32_exec_ADDC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDCO - Add Carrying with Overflow */
-static fastcall int ppc32_exec_ADDCO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDCO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -512,7 +512,7 @@ static fastcall int ppc32_exec_ADDCO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDCO. */
-static fastcall int ppc32_exec_ADDCO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDCO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -531,7 +531,7 @@ static fastcall int ppc32_exec_ADDCO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDE - Add Extended */
-static fastcall int ppc32_exec_ADDE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -554,7 +554,7 @@ static fastcall int ppc32_exec_ADDE(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDE. */
-static fastcall int ppc32_exec_ADDE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -578,7 +578,7 @@ static fastcall int ppc32_exec_ADDE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDEO - Add Extended with Overflow */
-static fastcall int ppc32_exec_ADDEO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDEO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -602,7 +602,7 @@ static fastcall int ppc32_exec_ADDEO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDEO. */
-static fastcall int ppc32_exec_ADDEO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDEO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -627,7 +627,7 @@ static fastcall int ppc32_exec_ADDEO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDI - ADD Immediate */
-static fastcall int ppc32_exec_ADDI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -644,7 +644,7 @@ static fastcall int ppc32_exec_ADDI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDIC - ADD Immediate with Carry */
-static fastcall int ppc32_exec_ADDIC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDIC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -659,7 +659,7 @@ static fastcall int ppc32_exec_ADDIC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDIC. */
-static fastcall int ppc32_exec_ADDIC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDIC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -675,7 +675,7 @@ static fastcall int ppc32_exec_ADDIC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDIS - ADD Immediate Shifted */
-static fastcall int ppc32_exec_ADDIS(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDIS(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -692,7 +692,7 @@ static fastcall int ppc32_exec_ADDIS(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDME - Add to Minus One Extended */
-static fastcall int ppc32_exec_ADDME(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDME(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -714,7 +714,7 @@ static fastcall int ppc32_exec_ADDME(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDME. */
-static fastcall int ppc32_exec_ADDME_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDME_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -737,7 +737,7 @@ static fastcall int ppc32_exec_ADDME_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDZE - Add to Zero Extended */
-static fastcall int ppc32_exec_ADDZE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDZE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -758,7 +758,7 @@ static fastcall int ppc32_exec_ADDZE(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDZE. */
-static fastcall int ppc32_exec_ADDZE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDZE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -780,7 +780,7 @@ static fastcall int ppc32_exec_ADDZE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* AND */
-static fastcall int ppc32_exec_AND(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_AND(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -791,7 +791,7 @@ static fastcall int ppc32_exec_AND(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* AND. */
-static fastcall int ppc32_exec_AND_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_AND_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -805,7 +805,7 @@ static fastcall int ppc32_exec_AND_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ANDC - AND with Complement */
-static fastcall int ppc32_exec_ANDC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ANDC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -816,7 +816,7 @@ static fastcall int ppc32_exec_ANDC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ANDC. - AND with Complement */
-static fastcall int ppc32_exec_ANDC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ANDC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -830,7 +830,7 @@ static fastcall int ppc32_exec_ANDC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ANDI. - AND Immediate */
-static fastcall int ppc32_exec_ANDI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ANDI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -844,7 +844,7 @@ static fastcall int ppc32_exec_ANDI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ANDIS. - AND Immediate Shifted */
-static fastcall int ppc32_exec_ANDIS_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ANDIS_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs  = bits(insn,21,25);
    int ra  = bits(insn,16,20);
@@ -858,7 +858,7 @@ static fastcall int ppc32_exec_ANDIS_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* B - Branch */
-static fastcall int ppc32_exec_B(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_B(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    m_uint32_t offset = bits(insn,2,25);
 
@@ -867,7 +867,7 @@ static fastcall int ppc32_exec_B(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BA - Branch Absolute */
-static fastcall int ppc32_exec_BA(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BA(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    m_uint32_t offset = bits(insn,2,25);
 
@@ -876,7 +876,7 @@ static fastcall int ppc32_exec_BA(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BL - Branch and Link */
-static fastcall int ppc32_exec_BL(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BL(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    m_uint32_t offset = bits(insn,2,25);
 
@@ -886,7 +886,7 @@ static fastcall int ppc32_exec_BL(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BLA - Branch and Link Absolute */
-static fastcall int ppc32_exec_BLA(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BLA(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    m_uint32_t offset = bits(insn,2,25);
 
@@ -896,7 +896,7 @@ static fastcall int ppc32_exec_BLA(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BC - Branch Conditional */
-static fastcall int ppc32_exec_BC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -911,7 +911,7 @@ static fastcall int ppc32_exec_BC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCA - Branch Conditional (absolute) */
-static fastcall int ppc32_exec_BCA(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCA(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -926,7 +926,7 @@ static fastcall int ppc32_exec_BCA(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCL - Branch Conditional and Link */
-static fastcall int ppc32_exec_BCL(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCL(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -943,7 +943,7 @@ static fastcall int ppc32_exec_BCL(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCLA - Branch Conditional and Link (absolute) */
-static fastcall int ppc32_exec_BCLA(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCLA(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -960,7 +960,7 @@ static fastcall int ppc32_exec_BCLA(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCLR - Branch Conditional to Link register */
-static fastcall int ppc32_exec_BCLR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCLR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -974,7 +974,7 @@ static fastcall int ppc32_exec_BCLR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCLRL - Branch Conditional to Link register */
-static fastcall int ppc32_exec_BCLRL(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCLRL(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -992,7 +992,7 @@ static fastcall int ppc32_exec_BCLRL(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCCTR - Branch Conditional to Count register */
-static fastcall int ppc32_exec_BCCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -1006,7 +1006,7 @@ static fastcall int ppc32_exec_BCCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCCTRL - Branch Conditional to Count register and Link */
-static fastcall int ppc32_exec_BCCTRL(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCCTRL(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -1022,7 +1022,7 @@ static fastcall int ppc32_exec_BCCTRL(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CMP - Compare */
-static fastcall int ppc32_exec_CMP(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CMP(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,23,25);
    int ra = bits(insn,16,20);
@@ -1050,7 +1050,7 @@ static fastcall int ppc32_exec_CMP(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CMPI - Compare Immediate */
-static fastcall int ppc32_exec_CMPI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CMPI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,23,25);
    int ra = bits(insn,16,20);
@@ -1078,7 +1078,7 @@ static fastcall int ppc32_exec_CMPI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CMPL - Compare Logical */
-static fastcall int ppc32_exec_CMPL(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CMPL(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,23,25);
    int ra = bits(insn,16,20);
@@ -1105,7 +1105,7 @@ static fastcall int ppc32_exec_CMPL(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CMPLI - Compare Logical Immediate */
-static fastcall int ppc32_exec_CMPLI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CMPLI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,23,25);
    int ra = bits(insn,16,20);
@@ -1131,7 +1131,7 @@ static fastcall int ppc32_exec_CMPLI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CNTLZW - Count Leading Zeros Word */
-static fastcall int ppc32_exec_CNTLZW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CNTLZW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1153,7 +1153,7 @@ static fastcall int ppc32_exec_CNTLZW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CRAND - Condition Register AND */
-static fastcall int ppc32_exec_CRAND(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CRAND(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1172,7 +1172,7 @@ static fastcall int ppc32_exec_CRAND(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CREQV - Condition Register Equivalent */
-static fastcall int ppc32_exec_CREQV(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CREQV(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1191,7 +1191,7 @@ static fastcall int ppc32_exec_CREQV(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CRANDC - Condition Register AND with Complement */
-static fastcall int ppc32_exec_CRANDC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CRANDC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1210,7 +1210,7 @@ static fastcall int ppc32_exec_CRANDC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CRNAND - Condition Register NAND */
-static fastcall int ppc32_exec_CRNAND(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CRNAND(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1229,7 +1229,7 @@ static fastcall int ppc32_exec_CRNAND(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CRNOR - Condition Register NOR */
-static fastcall int ppc32_exec_CRNOR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CRNOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1248,7 +1248,7 @@ static fastcall int ppc32_exec_CRNOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CROR - Condition Register OR */
-static fastcall int ppc32_exec_CROR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CROR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1267,7 +1267,7 @@ static fastcall int ppc32_exec_CROR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CRORC - Condition Register OR with complement */
-static fastcall int ppc32_exec_CRORC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CRORC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1286,7 +1286,7 @@ static fastcall int ppc32_exec_CRORC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CRXOR - Condition Register XOR */
-static fastcall int ppc32_exec_CRXOR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CRXOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1305,7 +1305,7 @@ static fastcall int ppc32_exec_CRXOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DCBF - Data Cache Block Flush */
-static fastcall int ppc32_exec_DCBF(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DCBF(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -1321,7 +1321,7 @@ static fastcall int ppc32_exec_DCBF(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DCBI - Data Cache Block Invalidate */
-static fastcall int ppc32_exec_DCBI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DCBI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -1337,7 +1337,7 @@ static fastcall int ppc32_exec_DCBI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DCBT - Data Cache Block Touch */
-static fastcall int ppc32_exec_DCBT(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DCBT(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -1353,7 +1353,7 @@ static fastcall int ppc32_exec_DCBT(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DCBST - Data Cache Block Store */
-static fastcall int ppc32_exec_DCBST(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DCBST(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -1369,7 +1369,7 @@ static fastcall int ppc32_exec_DCBST(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DIVW - Divide Word */
-static fastcall int ppc32_exec_DIVW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DIVW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1385,7 +1385,7 @@ static fastcall int ppc32_exec_DIVW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DIVW. - Divide Word */
-static fastcall int ppc32_exec_DIVW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DIVW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1405,7 +1405,7 @@ static fastcall int ppc32_exec_DIVW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DIVWU - Divide Word Unsigned */
-static fastcall int ppc32_exec_DIVWU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DIVWU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1421,7 +1421,7 @@ static fastcall int ppc32_exec_DIVWU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DIVWU. - Divide Word Unsigned */
-static fastcall int ppc32_exec_DIVWU_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DIVWU_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1441,13 +1441,13 @@ static fastcall int ppc32_exec_DIVWU_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* EIEIO - Enforce In-order Execution of I/O */
-static fastcall int ppc32_exec_EIEIO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_EIEIO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    return(0);
 }
 
 /* EQV */
-static fastcall int ppc32_exec_EQV(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_EQV(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1458,7 +1458,7 @@ static fastcall int ppc32_exec_EQV(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* EXTSB - Extend Sign Byte */
-static fastcall int ppc32_exec_EXTSB(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_EXTSB(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1468,7 +1468,7 @@ static fastcall int ppc32_exec_EXTSB(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* EXTSB. */
-static fastcall int ppc32_exec_EXTSB_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_EXTSB_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1481,7 +1481,7 @@ static fastcall int ppc32_exec_EXTSB_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* EXTSH - Extend Sign Word */
-static fastcall int ppc32_exec_EXTSH(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_EXTSH(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1491,7 +1491,7 @@ static fastcall int ppc32_exec_EXTSH(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* EXTSH. */
-static fastcall int ppc32_exec_EXTSH_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_EXTSH_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1504,7 +1504,7 @@ static fastcall int ppc32_exec_EXTSH_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ICBI - Instruction Cache Block Invalidate */
-static fastcall int ppc32_exec_ICBI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ICBI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -1520,13 +1520,13 @@ static fastcall int ppc32_exec_ICBI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ISYNC - Instruction Synchronize */
-static fastcall int ppc32_exec_ISYNC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ISYNC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    return(0);
 }
 
 /* LBZ - Load Byte and Zero */
-static fastcall int ppc32_exec_LBZ(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LBZ(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1543,7 +1543,7 @@ static fastcall int ppc32_exec_LBZ(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LBZU - Load Byte and Zero with Update */
-static fastcall int ppc32_exec_LBZU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LBZU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1557,7 +1557,7 @@ static fastcall int ppc32_exec_LBZU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LBZUX - Load Byte and Zero with Update Indexed */
-static fastcall int ppc32_exec_LBZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LBZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1571,7 +1571,7 @@ static fastcall int ppc32_exec_LBZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LBZX - Load Byte and Zero Indexed */
-static fastcall int ppc32_exec_LBZX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LBZX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1588,7 +1588,7 @@ static fastcall int ppc32_exec_LBZX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHA - Load Half-Word Algebraic */
-static fastcall int ppc32_exec_LHA(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHA(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1605,7 +1605,7 @@ static fastcall int ppc32_exec_LHA(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHAU - Load Half-Word Algebraic with Update */
-static fastcall int ppc32_exec_LHAU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHAU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1619,7 +1619,7 @@ static fastcall int ppc32_exec_LHAU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHAUX - Load Half-Word Algebraic with Update Indexed */
-static fastcall int ppc32_exec_LHAUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHAUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1633,7 +1633,7 @@ static fastcall int ppc32_exec_LHAUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHAX - Load Half-Word Algebraic ndexed */
-static fastcall int ppc32_exec_LHAX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHAX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1650,7 +1650,7 @@ static fastcall int ppc32_exec_LHAX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHZ - Load Half-Word and Zero */
-static fastcall int ppc32_exec_LHZ(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHZ(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1667,7 +1667,7 @@ static fastcall int ppc32_exec_LHZ(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHZU - Load Half-Word and Zero with Update */
-static fastcall int ppc32_exec_LHZU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHZU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1681,7 +1681,7 @@ static fastcall int ppc32_exec_LHZU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHZUX - Load Half-Word and Zero with Update Indexed */
-static fastcall int ppc32_exec_LHZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1695,7 +1695,7 @@ static fastcall int ppc32_exec_LHZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHZX - Load Half-Word and Zero Indexed */
-static fastcall int ppc32_exec_LHZX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHZX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1712,7 +1712,7 @@ static fastcall int ppc32_exec_LHZX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LMW - Load Multiple Word */
-static fastcall int ppc32_exec_LMW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LMW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1734,7 +1734,7 @@ static fastcall int ppc32_exec_LMW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LWBRX - Load Word Byte-Reverse Indexed */
-static fastcall int ppc32_exec_LWBRX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LWBRX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1751,7 +1751,7 @@ static fastcall int ppc32_exec_LWBRX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LWZ - Load Word and Zero */
-static fastcall int ppc32_exec_LWZ(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LWZ(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1768,7 +1768,7 @@ static fastcall int ppc32_exec_LWZ(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LWZU - Load Word and Zero with Update */
-static fastcall int ppc32_exec_LWZU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LWZU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1782,7 +1782,7 @@ static fastcall int ppc32_exec_LWZU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LWZUX - Load Word and Zero with Update Indexed */
-static fastcall int ppc32_exec_LWZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LWZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1796,7 +1796,7 @@ static fastcall int ppc32_exec_LWZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LWZX - Load Word and Zero Indexed */
-static fastcall int ppc32_exec_LWZX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LWZX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1813,7 +1813,7 @@ static fastcall int ppc32_exec_LWZX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LWARX - Load Word and Reserve Indexed */
-static fastcall int ppc32_exec_LWARX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LWARX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1831,7 +1831,7 @@ static fastcall int ppc32_exec_LWARX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LFD - Load Floating-Point Double */
-static fastcall int ppc32_exec_LFD(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LFD(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1848,7 +1848,7 @@ static fastcall int ppc32_exec_LFD(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LFDU - Load Floating-Point Double with Update */
-static fastcall int ppc32_exec_LFDU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LFDU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1862,7 +1862,7 @@ static fastcall int ppc32_exec_LFDU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LFDUX - Load Floating-Point Double with Update Indexed */
-static fastcall int ppc32_exec_LFDUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LFDUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1876,7 +1876,7 @@ static fastcall int ppc32_exec_LFDUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LFDX - Load Floating-Point Double Indexed */
-static fastcall int ppc32_exec_LFDX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LFDX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1893,7 +1893,7 @@ static fastcall int ppc32_exec_LFDX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LSWI - Load String Word Immediate */
-static fastcall int ppc32_exec_LSWI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LSWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1930,7 +1930,7 @@ static fastcall int ppc32_exec_LSWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LSWX - Load String Word Indexed */
-static fastcall int ppc32_exec_LSWX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LSWX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1967,7 +1967,7 @@ static fastcall int ppc32_exec_LSWX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MCRF - Move Condition Register Field */
-static fastcall int ppc32_exec_MCRF(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MCRF(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,23,25);
    int rs = bits(insn,18,20);
@@ -1977,7 +1977,7 @@ static fastcall int ppc32_exec_MCRF(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFCR - Move from Condition Register */
-static fastcall int ppc32_exec_MFCR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFCR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
 
@@ -1986,7 +1986,7 @@ static fastcall int ppc32_exec_MFCR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFMSR - Move from Machine State Register */
-static fastcall int ppc32_exec_MFMSR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFMSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
 
@@ -1995,7 +1995,7 @@ static fastcall int ppc32_exec_MFMSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFTBU - Move from Time Base (Up) */
-static fastcall int ppc32_exec_MFTBU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFTBU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
 
@@ -2004,7 +2004,7 @@ static fastcall int ppc32_exec_MFTBU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFTBL - Move from Time Base (Lo) */
-static fastcall int ppc32_exec_MFTBL(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFTBL(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
 
@@ -2015,7 +2015,7 @@ static fastcall int ppc32_exec_MFTBL(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFSPR - Move from Special-Purpose Register */
-static fastcall int ppc32_exec_MFSPR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFSPR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd   = bits(insn,21,25);
    int spr0 = bits(insn,16,20);
@@ -2099,7 +2099,7 @@ static fastcall int ppc32_exec_MFSPR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFSR - Move From Segment Register */
-static fastcall int ppc32_exec_MFSR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {   
    int rd = bits(insn,21,25);
    int sr = bits(insn,16,19);
@@ -2109,7 +2109,7 @@ static fastcall int ppc32_exec_MFSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFSRIN - Move From Segment Register Indirect */
-static fastcall int ppc32_exec_MFSRIN(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFSRIN(cpu_ppc_t *cpu,ppc_insn_t insn)
 {   
    int rd = bits(insn,21,25);
    int rb = bits(insn,11,15);
@@ -2119,7 +2119,7 @@ static fastcall int ppc32_exec_MFSRIN(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MTCRF - Move to Condition Register Fields */
-static fastcall int ppc32_exec_MTCRF(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTCRF(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int crm = bits(insn,12,19);
@@ -2133,7 +2133,7 @@ static fastcall int ppc32_exec_MTCRF(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MTMSR - Move to Machine State Register */
-static fastcall int ppc32_exec_MTMSR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTMSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
 
@@ -2145,7 +2145,7 @@ static fastcall int ppc32_exec_MTMSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MTSPR - Move to Special-Purpose Register */
-static fastcall int ppc32_exec_MTSPR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTSPR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd   = bits(insn,21,25);
    int spr0 = bits(insn,16,20);
@@ -2213,7 +2213,7 @@ static fastcall int ppc32_exec_MTSPR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MTSR - Move To Segment Register */
-static fastcall int ppc32_exec_MTSR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {   
    int rs = bits(insn,21,25);
    int sr = bits(insn,16,19);
@@ -2224,7 +2224,7 @@ static fastcall int ppc32_exec_MTSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULHW - Multiply High Word */
-static fastcall int ppc32_exec_MULHW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULHW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2241,7 +2241,7 @@ static fastcall int ppc32_exec_MULHW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULHW. */
-static fastcall int ppc32_exec_MULHW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULHW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2258,7 +2258,7 @@ static fastcall int ppc32_exec_MULHW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULHWU - Multiply High Word Unsigned */
-static fastcall int ppc32_exec_MULHWU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULHWU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2275,7 +2275,7 @@ static fastcall int ppc32_exec_MULHWU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULHWU. */
-static fastcall int ppc32_exec_MULHWU_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULHWU_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2292,7 +2292,7 @@ static fastcall int ppc32_exec_MULHWU_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULLI - Multiply Low Immediate */
-static fastcall int ppc32_exec_MULLI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULLI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2303,7 +2303,7 @@ static fastcall int ppc32_exec_MULLI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULLW - Multiply Low Word */
-static fastcall int ppc32_exec_MULLW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULLW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2317,7 +2317,7 @@ static fastcall int ppc32_exec_MULLW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULLW. */
-static fastcall int ppc32_exec_MULLW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULLW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2335,7 +2335,7 @@ static fastcall int ppc32_exec_MULLW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULLWO - Multiply Low Word with Overflow */
-static fastcall int ppc32_exec_MULLWO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULLWO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2355,7 +2355,7 @@ static fastcall int ppc32_exec_MULLWO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULLWO. */
-static fastcall int ppc32_exec_MULLWO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULLWO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2378,7 +2378,7 @@ static fastcall int ppc32_exec_MULLWO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NAND */
-static fastcall int ppc32_exec_NAND(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NAND(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2389,7 +2389,7 @@ static fastcall int ppc32_exec_NAND(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NAND. */
-static fastcall int ppc32_exec_NAND_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NAND_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2403,7 +2403,7 @@ static fastcall int ppc32_exec_NAND_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NEG - Negate */
-static fastcall int ppc32_exec_NEG(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NEG(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2413,7 +2413,7 @@ static fastcall int ppc32_exec_NEG(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NEG. */
-static fastcall int ppc32_exec_NEG_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NEG_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2426,7 +2426,7 @@ static fastcall int ppc32_exec_NEG_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NEGO */
-static fastcall int ppc32_exec_NEGO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NEGO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2445,7 +2445,7 @@ static fastcall int ppc32_exec_NEGO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NEGO. */
-static fastcall int ppc32_exec_NEGO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NEGO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2464,7 +2464,7 @@ static fastcall int ppc32_exec_NEGO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NOR */
-static fastcall int ppc32_exec_NOR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2475,7 +2475,7 @@ static fastcall int ppc32_exec_NOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NOR. */
-static fastcall int ppc32_exec_NOR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NOR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2489,7 +2489,7 @@ static fastcall int ppc32_exec_NOR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* OR */
-static fastcall int ppc32_exec_OR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_OR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2500,7 +2500,7 @@ static fastcall int ppc32_exec_OR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* OR. */
-static fastcall int ppc32_exec_OR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_OR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2514,7 +2514,7 @@ static fastcall int ppc32_exec_OR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ORC - OR with Complement */
-static fastcall int ppc32_exec_ORC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ORC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2525,7 +2525,7 @@ static fastcall int ppc32_exec_ORC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ORC. */
-static fastcall int ppc32_exec_ORC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ORC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2539,7 +2539,7 @@ static fastcall int ppc32_exec_ORC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ORI - OR Immediate */
-static fastcall int ppc32_exec_ORI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ORI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2550,7 +2550,7 @@ static fastcall int ppc32_exec_ORI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ORIS - OR Immediate Shifted */
-static fastcall int ppc32_exec_ORIS(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ORIS(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2561,7 +2561,7 @@ static fastcall int ppc32_exec_ORIS(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RFI - Return From Interrupt */
-static fastcall int ppc32_exec_RFI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RFI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    //printf("RFI: srr0=0x%8.8x, srr1=0x%8.8x\n",cpu->srr0,cpu->srr1);
 
@@ -2578,7 +2578,7 @@ static fastcall int ppc32_exec_RFI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RLWIMI - Rotate Left Word Immediate then Mask Insert */
-static fastcall int ppc32_exec_RLWIMI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RLWIMI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2594,7 +2594,7 @@ static fastcall int ppc32_exec_RLWIMI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RLWIMI. - Rotate Left Word Immediate then Mask Insert */
-static fastcall int ppc32_exec_RLWIMI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RLWIMI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2612,7 +2612,7 @@ static fastcall int ppc32_exec_RLWIMI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RLWINM - Rotate Left Word Immediate AND with Mask */
-static fastcall int ppc32_exec_RLWINM(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RLWINM(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2628,7 +2628,7 @@ static fastcall int ppc32_exec_RLWINM(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RLWINM. - Rotate Left Word Immediate AND with Mask */
-static fastcall int ppc32_exec_RLWINM_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RLWINM_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2646,7 +2646,7 @@ static fastcall int ppc32_exec_RLWINM_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RLWNM - Rotate Left Word then Mask Insert */
-static fastcall int ppc32_exec_RLWNM(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RLWNM(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2663,7 +2663,7 @@ static fastcall int ppc32_exec_RLWNM(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RLWNM. - Rotate Left Word then Mask Insert */
-static fastcall int ppc32_exec_RLWNM_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RLWNM_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2682,14 +2682,14 @@ static fastcall int ppc32_exec_RLWNM_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SC - System Call */
-static fastcall int ppc32_exec_SC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    ppc32_trigger_exception(cpu,PPC32_EXC_SYSCALL);
    return(1);
 }
 
 /* SLW - Shift Left Word */
-static fastcall int ppc32_exec_SLW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SLW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2707,7 +2707,7 @@ static fastcall int ppc32_exec_SLW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SLW. */
-static fastcall int ppc32_exec_SLW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SLW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2727,7 +2727,7 @@ static fastcall int ppc32_exec_SLW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SRAW - Shift Right Algebraic Word */
-static fastcall int ppc32_exec_SRAW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SRAW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2756,7 +2756,7 @@ static fastcall int ppc32_exec_SRAW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SRAWI - Shift Right Algebraic Word Immediate */
-static fastcall int ppc32_exec_SRAWI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SRAWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2776,7 +2776,7 @@ static fastcall int ppc32_exec_SRAWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SRAWI. */
-static fastcall int ppc32_exec_SRAWI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SRAWI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2798,7 +2798,7 @@ static fastcall int ppc32_exec_SRAWI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SRW - Shift Right Word */
-static fastcall int ppc32_exec_SRW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SRW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2816,7 +2816,7 @@ static fastcall int ppc32_exec_SRW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SRW. */
-static fastcall int ppc32_exec_SRW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SRW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2836,7 +2836,7 @@ static fastcall int ppc32_exec_SRW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STB - Store Byte */
-static fastcall int ppc32_exec_STB(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STB(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2853,7 +2853,7 @@ static fastcall int ppc32_exec_STB(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STBU - Store Byte with Update */
-static fastcall int ppc32_exec_STBU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STBU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2867,7 +2867,7 @@ static fastcall int ppc32_exec_STBU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STBUX - Store Byte with Update Indexed */
-static fastcall int ppc32_exec_STBUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STBUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2881,7 +2881,7 @@ static fastcall int ppc32_exec_STBUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STBX - Store Byte Indexed */
-static fastcall int ppc32_exec_STBX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STBX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2898,7 +2898,7 @@ static fastcall int ppc32_exec_STBX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STH - Store Half-Word */
-static fastcall int ppc32_exec_STH(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STH(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2915,7 +2915,7 @@ static fastcall int ppc32_exec_STH(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STHU - Store Half-Word with Update */
-static fastcall int ppc32_exec_STHU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STHU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs  = bits(insn,21,25);
    int ra  = bits(insn,16,20);
@@ -2929,7 +2929,7 @@ static fastcall int ppc32_exec_STHU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STHUX - Store Half-Word with Update Indexed */
-static fastcall int ppc32_exec_STHUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STHUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2943,7 +2943,7 @@ static fastcall int ppc32_exec_STHUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STHX - Store Half-Word Indexed */
-static fastcall int ppc32_exec_STHX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STHX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2960,7 +2960,7 @@ static fastcall int ppc32_exec_STHX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STMW - Store Multiple Word */
-static fastcall int ppc32_exec_STMW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STMW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2982,7 +2982,7 @@ static fastcall int ppc32_exec_STMW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STW - Store Word */
-static fastcall int ppc32_exec_STW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2999,7 +2999,7 @@ static fastcall int ppc32_exec_STW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STWU - Store Word with Update */
-static fastcall int ppc32_exec_STWU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STWU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3013,7 +3013,7 @@ static fastcall int ppc32_exec_STWU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STWUX - Store Word with Update Indexed */
-static fastcall int ppc32_exec_STWUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STWUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3027,7 +3027,7 @@ static fastcall int ppc32_exec_STWUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STWX - Store Word Indexed */
-static fastcall int ppc32_exec_STWX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STWX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3044,7 +3044,7 @@ static fastcall int ppc32_exec_STWX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STWBRX - Store Word Byte-Reverse Indexed */
-static fastcall int ppc32_exec_STWBRX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STWBRX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3061,7 +3061,7 @@ static fastcall int ppc32_exec_STWBRX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STWCX. - Store Word Conditional Indexed */
-static fastcall int ppc32_exec_STWCX_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STWCX_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3093,7 +3093,7 @@ static fastcall int ppc32_exec_STWCX_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STFD - Store Floating-Point Double */
-static fastcall int ppc32_exec_STFD(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STFD(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3110,7 +3110,7 @@ static fastcall int ppc32_exec_STFD(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STFDU - Store Floating-Point Double with Update */
-static fastcall int ppc32_exec_STFDU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STFDU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3124,7 +3124,7 @@ static fastcall int ppc32_exec_STFDU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STFDUX - Store Floating-Point Double with Update Indexed */
-static fastcall int ppc32_exec_STFDUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STFDUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3138,7 +3138,7 @@ static fastcall int ppc32_exec_STFDUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STFDX - Store Floating-Point Double Indexed */
-static fastcall int ppc32_exec_STFDX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STFDX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3155,7 +3155,7 @@ static fastcall int ppc32_exec_STFDX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STSWI - Store String Word Immediate */
-static fastcall int ppc32_exec_STSWI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STSWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3190,7 +3190,7 @@ static fastcall int ppc32_exec_STSWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STSWX - Store String Word Indexed */
-static fastcall int ppc32_exec_STSWX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STSWX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3225,7 +3225,7 @@ static fastcall int ppc32_exec_STSWX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBF - Subtract From */
-static fastcall int ppc32_exec_SUBF(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBF(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3236,7 +3236,7 @@ static fastcall int ppc32_exec_SUBF(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBF. */
-static fastcall int ppc32_exec_SUBF_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBF_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3250,7 +3250,7 @@ static fastcall int ppc32_exec_SUBF_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFO - Subtract From with Overflow */
-static fastcall int ppc32_exec_SUBFO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3267,7 +3267,7 @@ static fastcall int ppc32_exec_SUBFO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFO. */
-static fastcall int ppc32_exec_SUBFO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3285,7 +3285,7 @@ static fastcall int ppc32_exec_SUBFO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFC - Subtract From Carrying */
-static fastcall int ppc32_exec_SUBFC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3307,7 +3307,7 @@ static fastcall int ppc32_exec_SUBFC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFC. */
-static fastcall int ppc32_exec_SUBFC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3330,7 +3330,7 @@ static fastcall int ppc32_exec_SUBFC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFCO - Subtract From with Overflow */
-_Unused static fastcall int ppc32_exec_SUBFCO(cpu_ppc_t *cpu,ppc_insn_t insn)
+_Unused static int ppc32_exec_SUBFCO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3348,7 +3348,7 @@ _Unused static fastcall int ppc32_exec_SUBFCO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFCO. */
-_Unused static fastcall int ppc32_exec_SUBFCO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+_Unused static int ppc32_exec_SUBFCO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3367,7 +3367,7 @@ _Unused static fastcall int ppc32_exec_SUBFCO_dot(cpu_ppc_t *cpu,ppc_insn_t insn
 }
 
 /* SUBFE - Subtract From Carrying */
-static fastcall int ppc32_exec_SUBFE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3391,7 +3391,7 @@ static fastcall int ppc32_exec_SUBFE(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFIC - Subtract From Immediate Carrying */
-static fastcall int ppc32_exec_SUBFIC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFIC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3413,7 +3413,7 @@ static fastcall int ppc32_exec_SUBFIC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFZE - Subtract From Zero extended */
-static fastcall int ppc32_exec_SUBFZE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFZE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3433,7 +3433,7 @@ static fastcall int ppc32_exec_SUBFZE(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFZE. */
-static fastcall int ppc32_exec_SUBFZE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFZE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3454,33 +3454,33 @@ static fastcall int ppc32_exec_SUBFZE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SYNC - Synchronize */
-static fastcall int ppc32_exec_SYNC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SYNC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    return(0);
 }
 
 /* TLBIA - TLB Invalidate All */
-static fastcall int ppc32_exec_TLBIA(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TLBIA(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    ppc32_mem_invalidate_cache(cpu);
    return(0);
 }
 
 /* TLBIE - TLB Invalidate Entry */
-static fastcall int ppc32_exec_TLBIE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TLBIE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    ppc32_mem_invalidate_cache(cpu);
    return(0);
 }
 
 /* TLBSYNC - TLB Synchronize */
-static fastcall int ppc32_exec_TLBSYNC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TLBSYNC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    return(0);
 }
 
 /* TW - Trap Word */
-static fastcall int ppc32_exec_TW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int to = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3505,7 +3505,7 @@ static fastcall int ppc32_exec_TW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* TWI - Trap Word Immediate */
-static fastcall int ppc32_exec_TWI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int to = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3530,7 +3530,7 @@ static fastcall int ppc32_exec_TWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* XOR */
-static fastcall int ppc32_exec_XOR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_XOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3541,7 +3541,7 @@ static fastcall int ppc32_exec_XOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* XOR. */
-static fastcall int ppc32_exec_XOR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_XOR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3555,7 +3555,7 @@ static fastcall int ppc32_exec_XOR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* XORI - XOR Immediate */
-static fastcall int ppc32_exec_XORI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_XORI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3566,7 +3566,7 @@ static fastcall int ppc32_exec_XORI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* XORIS - XOR Immediate Shifted */
-static fastcall int ppc32_exec_XORIS(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_XORIS(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3577,7 +3577,7 @@ static fastcall int ppc32_exec_XORIS(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DCCCI - Data Cache Congruence Class Invalidate (PowerPC 405) */
-static fastcall int ppc32_exec_DCCCI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DCCCI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -3592,7 +3592,7 @@ static fastcall int ppc32_exec_DCCCI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ICCCI - Instruction Cache Congruence Class Invalidate (PowerPC 405) */
-static fastcall int ppc32_exec_ICCCI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ICCCI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -3607,21 +3607,21 @@ static fastcall int ppc32_exec_ICCCI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFDCR - Move From Device Control Register (PowerPC 405) */
-static fastcall int ppc32_exec_MFDCR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFDCR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int UNUSED(rt) = bits(insn,21,25);
    return(0);
 }
 
 /* MTDCR - Move To Device Control Register (PowerPC 405) */
-static fastcall int ppc32_exec_MTDCR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTDCR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int UNUSED(rt) = bits(insn,21,25);
    return(0);
 }
 
 /* TLBRE - TLB Read Entry (PowerPC 405) */
-static fastcall int ppc32_exec_TLBRE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TLBRE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rt = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3641,7 +3641,7 @@ static fastcall int ppc32_exec_TLBRE(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* TLBWE - TLB Write Entry (PowerPC 405) */
-static fastcall int ppc32_exec_TLBWE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TLBWE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);

--- a/stable/ppc32_exec.c
+++ b/stable/ppc32_exec.c
@@ -150,7 +150,7 @@ ppc32_exec_single_instruction(cpu_ppc_t *cpu,ppc_insn_t instruction)
 }
 
 /* Execute a single instruction (external) */
-fastcall int ppc32_exec_single_insn_ext(cpu_ppc_t *cpu,ppc_insn_t insn)
+int ppc32_exec_single_insn_ext(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int res;
 

--- a/stable/ppc32_exec.c
+++ b/stable/ppc32_exec.c
@@ -160,7 +160,7 @@ int ppc32_exec_single_insn_ext(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* Execute a page */
-fastcall int ppc32_exec_page(cpu_ppc_t *cpu)
+int ppc32_exec_page(cpu_ppc_t *cpu)
 {
    m_uint32_t exec_page,offset;
    ppc_insn_t insn;

--- a/stable/ppc32_exec.c
+++ b/stable/ppc32_exec.c
@@ -93,7 +93,7 @@ void ppc32_dump_stats(cpu_ppc_t *cpu)
 static forced_inline void ppc32_exec_memop(cpu_ppc_t *cpu,int memop,
                                            m_uint32_t vaddr,u_int dst_reg)
 {     
-   fastcall ppc_memop_fn fn;
+   ppc_memop_fn fn;
     
    fn = cpu->mem_op_fn[memop];
    fn(cpu,vaddr,dst_reg);

--- a/stable/ppc32_mem.c
+++ b/stable/ppc32_mem.c
@@ -724,7 +724,6 @@ static void ppc405_dump_tlb(cpu_gen_t *cpu)
 /* === PPC Memory Operations ============================================= */
 
 /* LBZ: Load Byte Zero */
-__attribute__((force_align_arg_pointer))
 void ppc32_lbz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -736,7 +735,6 @@ void ppc32_lbz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LHZ: Load Half-Word Zero */
-__attribute__((force_align_arg_pointer))
 void ppc32_lhz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -748,7 +746,6 @@ void ppc32_lhz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LWZ: Load Word Zero */
-__attribute__((force_align_arg_pointer))
 void ppc32_lwz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -760,7 +757,6 @@ void ppc32_lwz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LWBR: Load Word Byte Reverse */
-__attribute__((force_align_arg_pointer))
 void ppc32_lwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -772,7 +768,6 @@ void ppc32_lwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LHA: Load Half-Word Algebraic */
-__attribute__((force_align_arg_pointer))
 void ppc32_lha(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -784,7 +779,6 @@ void ppc32_lha(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STB: Store Byte */
-__attribute__((force_align_arg_pointer))
 void ppc32_stb(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -796,7 +790,6 @@ void ppc32_stb(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STH: Store Half-Word */
-__attribute__((force_align_arg_pointer))
 void ppc32_sth(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -808,7 +801,6 @@ void ppc32_sth(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STW: Store Word */
-__attribute__((force_align_arg_pointer))
 void ppc32_stw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -820,7 +812,6 @@ void ppc32_stw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STWBR: Store Word Byte Reversed */
-__attribute__((force_align_arg_pointer))
 void ppc32_stwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -832,7 +823,6 @@ void ppc32_stwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LSW: Load String Word */
-__attribute__((force_align_arg_pointer))
 void ppc32_lsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -844,7 +834,6 @@ void ppc32_lsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STW: Store String Word */
-__attribute__((force_align_arg_pointer))
 void ppc32_stsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -856,7 +845,6 @@ void ppc32_stsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LFD: Load Floating-Point Double */
-__attribute__((force_align_arg_pointer))
 void ppc32_lfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -868,7 +856,6 @@ void ppc32_lfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STFD: Store Floating-Point Double */
-__attribute__((force_align_arg_pointer))
 void ppc32_stfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
@@ -880,7 +867,6 @@ void ppc32_stfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* ICBI: Instruction Cache Block Invalidate */
-__attribute__((force_align_arg_pointer))
 void ppc32_icbi(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int op)
 {
    ppc32_jit_tcb_t *block;

--- a/stable/ppc32_mem.c
+++ b/stable/ppc32_mem.c
@@ -725,7 +725,7 @@ static void ppc405_dump_tlb(cpu_gen_t *cpu)
 
 /* LBZ: Load Byte Zero */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_lbz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lbz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -737,7 +737,7 @@ fastcall void ppc32_lbz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* LHZ: Load Half-Word Zero */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_lhz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lhz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -749,7 +749,7 @@ fastcall void ppc32_lhz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* LWZ: Load Word Zero */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_lwz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lwz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -761,7 +761,7 @@ fastcall void ppc32_lwz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* LWBR: Load Word Byte Reverse */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_lwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -773,7 +773,7 @@ fastcall void ppc32_lwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* LHA: Load Half-Word Algebraic */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_lha(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lha(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -785,7 +785,7 @@ fastcall void ppc32_lha(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* STB: Store Byte */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_stb(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_stb(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -797,7 +797,7 @@ fastcall void ppc32_stb(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* STH: Store Half-Word */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_sth(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_sth(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -809,7 +809,7 @@ fastcall void ppc32_sth(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* STW: Store Word */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_stw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_stw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -821,7 +821,7 @@ fastcall void ppc32_stw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* STWBR: Store Word Byte Reversed */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_stwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_stwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -833,7 +833,7 @@ fastcall void ppc32_stwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* LSW: Load String Word */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_lsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -845,7 +845,7 @@ fastcall void ppc32_lsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* STW: Store String Word */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_stsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_stsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -857,7 +857,7 @@ fastcall void ppc32_stsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* LFD: Load Floating-Point Double */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_lfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -869,7 +869,7 @@ fastcall void ppc32_lfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* STFD: Store Floating-Point Double */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_stfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_stfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -881,7 +881,7 @@ fastcall void ppc32_stfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 
 /* ICBI: Instruction Cache Block Invalidate */
 __attribute__((force_align_arg_pointer))
-fastcall void ppc32_icbi(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int op)
+void ppc32_icbi(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int op)
 {
    ppc32_jit_tcb_t *block;
    m_uint32_t phys_page;

--- a/stable/ppc32_mem.c
+++ b/stable/ppc32_mem.c
@@ -456,7 +456,7 @@ static inline void *ppc32_mem_access(cpu_ppc_t *cpu,m_uint32_t vaddr,
                     (op_type),(data))
 
 /* Virtual address to physical page translation */
-static fastcall int ppc32_translate(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int cid,
+static int ppc32_translate(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int cid,
                                     m_uint32_t *phys_page)
 {   
    mts32_entry_t *entry,alt_entry;

--- a/stable/ppc32_x86_trans.c
+++ b/stable/ppc32_x86_trans.c
@@ -687,8 +687,9 @@ void ppc32_emit_breakpoint(cpu_ppc_t *cpu,ppc32_jit_tcb_t *b)
 
    iop = ppc32_op_emit_insn_output(cpu,2,"breakpoint");
 
-   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST);
    x86_mov_reg_reg(iop->ob_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST-4);
+   x86_push_reg(iop->ob_ptr,X86_EAX);
    ppc32_emit_c_call(b,iop,ppc32_run_breakpoint);
    x86_alu_reg_imm(iop->ob_ptr,X86_ADD,X86_ESP,STACK_ADJUST);
 

--- a/stable/ppc32_x86_trans.c
+++ b/stable/ppc32_x86_trans.c
@@ -411,7 +411,10 @@ static void ppc32_emit_memop(cpu_ppc_t *cpu,ppc32_jit_tcb_t *b,
    x86_mov_reg_reg(iop->ob_ptr,X86_EAX,X86_EDI,4);
 
    /* Call memory function */
-   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST);
+   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST-12);
+   x86_push_reg(iop->ob_ptr,X86_ECX);
+   x86_push_reg(iop->ob_ptr,X86_EDX);
+   x86_push_reg(iop->ob_ptr,X86_EAX);
    x86_call_membase(iop->ob_ptr,X86_EDI,MEMOP_OFFSET(op));
    x86_alu_reg_imm(iop->ob_ptr,X86_ADD,X86_ESP,STACK_ADJUST);
    
@@ -454,7 +457,10 @@ static void ppc32_emit_memop_idx(cpu_ppc_t *cpu,ppc32_jit_tcb_t *b,
    x86_mov_reg_reg(iop->ob_ptr,X86_EAX,X86_EDI,4);
 
    /* Call memory function */
-   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST);
+   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST-12);
+   x86_push_reg(iop->ob_ptr,X86_ECX);
+   x86_push_reg(iop->ob_ptr,X86_EDX);
+   x86_push_reg(iop->ob_ptr,X86_EAX);
    x86_call_membase(iop->ob_ptr,X86_EDI,MEMOP_OFFSET(op));
    x86_alu_reg_imm(iop->ob_ptr,X86_ADD,X86_ESP,STACK_ADJUST);
    
@@ -627,7 +633,10 @@ static void ppc32_emit_memop_fast(cpu_ppc_t *cpu,ppc32_jit_tcb_t *b,
    x86_mov_reg_reg(iop->ob_ptr,X86_EAX,X86_EDI,4);
 
    /* Call memory function */
-   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST);
+   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST-12);
+   x86_push_reg(iop->ob_ptr,X86_ECX);
+   x86_push_reg(iop->ob_ptr,X86_EDX);
+   x86_push_reg(iop->ob_ptr,X86_EAX);
    x86_call_membase(iop->ob_ptr,X86_EDI,MEMOP_OFFSET(opcode));
    x86_alu_reg_imm(iop->ob_ptr,X86_ADD,X86_ESP,STACK_ADJUST);
    

--- a/stable/ppc32_x86_trans.c
+++ b/stable/ppc32_x86_trans.c
@@ -661,10 +661,12 @@ static int ppc32_emit_unknown(cpu_ppc_t *cpu,ppc32_jit_tcb_t *b,
    ppc32_set_ia(&iop->ob_ptr,b->start_ia+(b->ppc_trans_pos << 2));
 
    /* Fallback to non-JIT mode */
-   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST);
    x86_mov_reg_reg(iop->ob_ptr,X86_EAX,X86_EDI,4);
    x86_mov_reg_imm(iop->ob_ptr,X86_EDX,opcode);
 
+   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST-8);
+   x86_push_reg(iop->ob_ptr,X86_EDX);
+   x86_push_reg(iop->ob_ptr,X86_EAX);
    ppc32_emit_basic_c_call(&iop->ob_ptr,ppc32_exec_single_insn_ext);
    x86_alu_reg_imm(iop->ob_ptr,X86_ADD,X86_ESP,STACK_ADJUST);
    

--- a/unstable/mips64.c
+++ b/unstable/mips64.c
@@ -526,7 +526,7 @@ void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu)
 }
 
 /* Trigger the Timer IRQ */
-fastcall void mips64_trigger_timer_irq(cpu_mips_t *cpu)
+void mips64_trigger_timer_irq(cpu_mips_t *cpu)
 {
    mips_cp0_t *cp0 = &cpu->cp0;
 

--- a/unstable/mips64.c
+++ b/unstable/mips64.c
@@ -558,7 +558,7 @@ void mips64_exec_eret(cpu_mips_t *cpu)
 }
 
 /* Execute SYSCALL instruction */
-fastcall void mips64_exec_syscall(cpu_mips_t *cpu)
+void mips64_exec_syscall(cpu_mips_t *cpu)
 {
 #if DEBUG_SYSCALL
    printf("MIPS64: SYSCALL at PC=0x%llx (RA=0x%llx)\n"

--- a/unstable/mips64.c
+++ b/unstable/mips64.c
@@ -680,7 +680,7 @@ void mips64_remove_breakpoint(cpu_gen_t *cpu,m_uint64_t pc)
 }
 
 /* Debugging for register-jump to address 0 */
-fastcall void mips64_debug_jr0(cpu_mips_t *cpu)
+void mips64_debug_jr0(cpu_mips_t *cpu)
 {
    printf("MIPS64: cpu %p jumping to address 0...\n",cpu);
    mips64_dump_regs(cpu->gen);

--- a/unstable/mips64.c
+++ b/unstable/mips64.c
@@ -538,7 +538,7 @@ void mips64_trigger_timer_irq(cpu_mips_t *cpu)
 }
 
 /* Execute ERET instruction */
-fastcall void mips64_exec_eret(cpu_mips_t *cpu)
+void mips64_exec_eret(cpu_mips_t *cpu)
 {
    mips_cp0_t *cp0 = &cpu->cp0;
 

--- a/unstable/mips64.c
+++ b/unstable/mips64.c
@@ -510,7 +510,7 @@ void mips64_prepare_tlb_exception(cpu_mips_t *cpu,m_uint64_t vaddr)
  * Increment count register and trigger the timer IRQ if value in compare 
  * register is the same.
  */
-fastcall void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu)
+void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu)
 {
    cpu->cp0_virt_cnt_reg++;
 

--- a/unstable/mips64.c
+++ b/unstable/mips64.c
@@ -585,7 +585,7 @@ void mips64_trigger_trap_exception(cpu_mips_t *cpu)
 }
 
 /* Trigger IRQs */
-fastcall void mips64_trigger_irq(cpu_mips_t *cpu)
+void mips64_trigger_irq(cpu_mips_t *cpu)
 {
    if (unlikely(cpu->irq_disable)) {
       cpu->irq_pending = 0;

--- a/unstable/mips64.c
+++ b/unstable/mips64.c
@@ -571,7 +571,7 @@ void mips64_exec_syscall(cpu_mips_t *cpu)
 }
 
 /* Execute BREAK instruction */
-fastcall void mips64_exec_break(cpu_mips_t *cpu,u_int code)
+void mips64_exec_break(cpu_mips_t *cpu,u_int code)
 {
    cpu_log(cpu->gen,"MIPS64","BREAK instruction (code=%u)\n",code);
    mips64_general_exception(cpu,MIPS_CP0_CAUSE_BP);

--- a/unstable/mips64.c
+++ b/unstable/mips64.c
@@ -578,7 +578,7 @@ void mips64_exec_break(cpu_mips_t *cpu,u_int code)
 }
 
 /* Trigger a Trap Exception */
-fastcall void mips64_trigger_trap_exception(cpu_mips_t *cpu)
+void mips64_trigger_trap_exception(cpu_mips_t *cpu)
 {  
    cpu_log(cpu->gen,"MIPS64","TRAP exception\n");
    mips64_general_exception(cpu,MIPS_CP0_CAUSE_TRAP);

--- a/unstable/mips64.c
+++ b/unstable/mips64.c
@@ -600,19 +600,19 @@ fastcall void mips64_trigger_irq(cpu_mips_t *cpu)
 }
 
 /* DMFC1 */
-fastcall void mips64_exec_dmfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
+void mips64_exec_dmfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
 {
    cpu->gpr[gp_reg] = cpu->fpu.reg[cp1_reg];
 }
 
 /* DMTC1 */
-fastcall void mips64_exec_dmtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
+void mips64_exec_dmtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
 {
    cpu->fpu.reg[cp1_reg] = cpu->gpr[gp_reg];
 }
 
 /* MFC1 */
-fastcall void mips64_exec_mfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
+void mips64_exec_mfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
 {
    m_int64_t val;
 
@@ -621,7 +621,7 @@ fastcall void mips64_exec_mfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
 }
 
 /* MTC1 */
-fastcall void mips64_exec_mtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
+void mips64_exec_mtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
 {
    cpu->fpu.reg[cp1_reg] = cpu->gpr[gp_reg] & 0xffffffff;
 }

--- a/unstable/mips64.c
+++ b/unstable/mips64.c
@@ -627,7 +627,7 @@ void mips64_exec_mtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg)
 }
 
 /* Virtual breakpoint */
-fastcall void mips64_run_breakpoint(cpu_mips_t *cpu)
+void mips64_run_breakpoint(cpu_mips_t *cpu)
 {
    cpu_log(cpu->gen,"BREAKPOINT",
            "Virtual breakpoint reached at PC=0x%llx\n",cpu->pc);

--- a/unstable/mips64.h
+++ b/unstable/mips64.h
@@ -541,7 +541,7 @@ void mips64_prepare_tlb_exception(cpu_mips_t *cpu,m_uint64_t vaddr);
  * Increment count register and trigger the timer IRQ if value in compare 
  * register is the same.
  */
-fastcall void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu);
+void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu);
 
 /* Trigger the Timer IRQ */
 fastcall void mips64_trigger_timer_irq(cpu_mips_t *cpu);

--- a/unstable/mips64.h
+++ b/unstable/mips64.h
@@ -559,7 +559,7 @@ void mips64_exec_break(cpu_mips_t *cpu,u_int code);
 void mips64_trigger_trap_exception(cpu_mips_t *cpu);
 
 /* Trigger IRQs */
-fastcall void mips64_trigger_irq(cpu_mips_t *cpu);
+void mips64_trigger_irq(cpu_mips_t *cpu);
 
 /* Set an IRQ */
 void mips64_set_irq(cpu_mips_t *cpu,m_uint8_t irq);

--- a/unstable/mips64.h
+++ b/unstable/mips64.h
@@ -556,7 +556,7 @@ void mips64_exec_syscall(cpu_mips_t *cpu);
 void mips64_exec_break(cpu_mips_t *cpu,u_int code);
 
 /* Trigger a Trap Exception */
-fastcall void mips64_trigger_trap_exception(cpu_mips_t *cpu);
+void mips64_trigger_trap_exception(cpu_mips_t *cpu);
 
 /* Trigger IRQs */
 fastcall void mips64_trigger_irq(cpu_mips_t *cpu);

--- a/unstable/mips64.h
+++ b/unstable/mips64.h
@@ -550,7 +550,7 @@ void mips64_trigger_timer_irq(cpu_mips_t *cpu);
 void mips64_exec_eret(cpu_mips_t *cpu);
 
 /* Execute SYSCALL instruction */
-fastcall void mips64_exec_syscall(cpu_mips_t *cpu);
+void mips64_exec_syscall(cpu_mips_t *cpu);
 
 /* Execute BREAK instruction */
 fastcall void mips64_exec_break(cpu_mips_t *cpu,u_int code);

--- a/unstable/mips64.h
+++ b/unstable/mips64.h
@@ -547,7 +547,7 @@ void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu);
 void mips64_trigger_timer_irq(cpu_mips_t *cpu);
 
 /* Execute ERET instruction */
-fastcall void mips64_exec_eret(cpu_mips_t *cpu);
+void mips64_exec_eret(cpu_mips_t *cpu);
 
 /* Execute SYSCALL instruction */
 fastcall void mips64_exec_syscall(cpu_mips_t *cpu);

--- a/unstable/mips64.h
+++ b/unstable/mips64.h
@@ -386,7 +386,7 @@ struct cpu_mips {
    u_int bd_slot;
    
    /* Virtual address to physical page translation */
-   fastcall int (*translate)(cpu_mips_t *cpu,m_uint64_t vaddr,
+   int (*translate)(cpu_mips_t *cpu,m_uint64_t vaddr,
                              m_uint32_t *phys_page);
 
    /* Memory access functions */

--- a/unstable/mips64.h
+++ b/unstable/mips64.h
@@ -338,7 +338,7 @@ enum {
 typedef struct cpu_mips cpu_mips_t;
 
 /* Memory operation function prototype */
-typedef fastcall void (*mips_memop_fn)(cpu_mips_t *cpu,m_uint64_t vaddr,
+typedef void (*mips_memop_fn)(cpu_mips_t *cpu,m_uint64_t vaddr,
                                        u_int reg);
 
 /* TLB entry definition */

--- a/unstable/mips64.h
+++ b/unstable/mips64.h
@@ -589,7 +589,7 @@ int mips64_add_breakpoint(cpu_gen_t *cpu,m_uint64_t pc);
 void mips64_remove_breakpoint(cpu_gen_t *cpu,m_uint64_t pc);
 
 /* Debugging for register-jump to address 0 */
-fastcall void mips64_debug_jr0(cpu_mips_t *cpu);
+void mips64_debug_jr0(cpu_mips_t *cpu);
 
 /* Set a register */
 void mips64_reg_set(cpu_gen_t *cpu,u_int reg,m_uint64_t val);

--- a/unstable/mips64.h
+++ b/unstable/mips64.h
@@ -568,16 +568,16 @@ void mips64_set_irq(cpu_mips_t *cpu,m_uint8_t irq);
 void mips64_clear_irq(cpu_mips_t *cpu,m_uint8_t irq);
 
 /* DMFC1 */
-fastcall void mips64_exec_dmfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
+void mips64_exec_dmfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
 
 /* DMTC1 */
-fastcall void mips64_exec_dmtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
+void mips64_exec_dmtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
 
 /* MFC1 */
-fastcall void mips64_exec_mfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
+void mips64_exec_mfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
 
 /* MTC1 */
-fastcall void mips64_exec_mtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
+void mips64_exec_mtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
 
 /* Virtual breakpoint */
 fastcall void mips64_run_breakpoint(cpu_mips_t *cpu);

--- a/unstable/mips64.h
+++ b/unstable/mips64.h
@@ -580,7 +580,7 @@ void mips64_exec_mfc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
 void mips64_exec_mtc1(cpu_mips_t *cpu,u_int gp_reg,u_int cp1_reg);
 
 /* Virtual breakpoint */
-fastcall void mips64_run_breakpoint(cpu_mips_t *cpu);
+void mips64_run_breakpoint(cpu_mips_t *cpu);
 
 /* Add a virtual breakpoint */
 int mips64_add_breakpoint(cpu_gen_t *cpu,m_uint64_t pc);

--- a/unstable/mips64.h
+++ b/unstable/mips64.h
@@ -553,7 +553,7 @@ void mips64_exec_eret(cpu_mips_t *cpu);
 void mips64_exec_syscall(cpu_mips_t *cpu);
 
 /* Execute BREAK instruction */
-fastcall void mips64_exec_break(cpu_mips_t *cpu,u_int code);
+void mips64_exec_break(cpu_mips_t *cpu,u_int code);
 
 /* Trigger a Trap Exception */
 fastcall void mips64_trigger_trap_exception(cpu_mips_t *cpu);

--- a/unstable/mips64.h
+++ b/unstable/mips64.h
@@ -544,7 +544,7 @@ void mips64_prepare_tlb_exception(cpu_mips_t *cpu,m_uint64_t vaddr);
 void mips64_exec_inc_cp0_cnt(cpu_mips_t *cpu);
 
 /* Trigger the Timer IRQ */
-fastcall void mips64_trigger_timer_irq(cpu_mips_t *cpu);
+void mips64_trigger_timer_irq(cpu_mips_t *cpu);
 
 /* Execute ERET instruction */
 fastcall void mips64_exec_eret(cpu_mips_t *cpu);

--- a/unstable/mips64_amd64_trans.c
+++ b/unstable/mips64_amd64_trans.c
@@ -453,7 +453,7 @@ static void mips64_emit_memop(cpu_tc_t *b,int op,int base,int offset,
 }
 
 /* Coprocessor Register transfert operation */
-static void mips64_emit_cp_xfr_op(cpu_tc_t *b,int rt,int rd,void *f)
+static void mips64_emit_cp_xfr_op(cpu_tc_t *b,int rt,int rd,void (*f)(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg))
 {
    /* update pc */
    mips64_set_pc(b,b->vaddr+((b->trans_pos-1)<<2));

--- a/unstable/mips64_amd64_trans.c
+++ b/unstable/mips64_amd64_trans.c
@@ -506,7 +506,7 @@ static int mips64_emit_unknown(cpu_mips_t *cpu,cpu_tc_t *b,
 }
 
 /* Invalid delay slot handler */
-static fastcall void mips64_invalid_delay_slot(cpu_mips_t *cpu)
+static void mips64_invalid_delay_slot(cpu_mips_t *cpu)
 {
    printf("MIPS64: invalid instruction in delay slot at 0x%llx (ra=0x%llx)\n",
           cpu->pc,cpu->gpr[MIPS_GPR_RA]);

--- a/unstable/mips64_amd64_trans.c
+++ b/unstable/mips64_amd64_trans.c
@@ -482,7 +482,7 @@ void mips64_emit_breakpoint(cpu_tc_t *b)
 }
 
 /* Unknown opcode handler */
-static fastcall void mips64_unknown_opcode(cpu_mips_t *cpu,m_uint32_t opcode)
+static void mips64_unknown_opcode(cpu_mips_t *cpu,m_uint32_t opcode)
 {
    printf("CPU = %p\n",cpu);
 

--- a/unstable/mips64_cp0.c
+++ b/unstable/mips64_cp0.c
@@ -436,7 +436,7 @@ int mips64_cp0_tlb_lookup(cpu_mips_t *cpu,m_uint64_t vaddr,
 }
 
 /* TLBP: Probe a TLB entry */
-fastcall void mips64_cp0_exec_tlbp(cpu_mips_t *cpu)
+void mips64_cp0_exec_tlbp(cpu_mips_t *cpu)
 {
    mips_cp0_t *cp0 = &cpu->cp0;
    m_uint64_t hi_reg,asid;

--- a/unstable/mips64_cp0.c
+++ b/unstable/mips64_cp0.c
@@ -555,7 +555,7 @@ void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu)
 }
 
 /* TLBWR: Write Random TLB entry */
-fastcall void mips64_cp0_exec_tlbwr(cpu_mips_t *cpu)
+void mips64_cp0_exec_tlbwr(cpu_mips_t *cpu)
 {
    mips64_cp0_exec_tlbw(cpu,mips64_cp0_get_random_reg(cpu));
 }

--- a/unstable/mips64_cp0.c
+++ b/unstable/mips64_cp0.c
@@ -549,7 +549,7 @@ static inline void mips64_cp0_exec_tlbw(cpu_mips_t *cpu,u_int index)
 }
 
 /* TLBWI: Write Indexed TLB entry */
-fastcall void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu)
+void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu)
 {
    mips64_cp0_exec_tlbw(cpu,cpu->cp0.reg[MIPS_CP0_INDEX]);
 }

--- a/unstable/mips64_cp0.c
+++ b/unstable/mips64_cp0.c
@@ -259,37 +259,37 @@ static inline void mips64_cp0_s1_set_reg(cpu_mips_t *cpu,u_int cp0_s1_reg,
 }
 
 /* DMFC0 */
-fastcall void mips64_cp0_exec_dmfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
+void mips64_cp0_exec_dmfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
 {
    cpu->gpr[gp_reg] = mips64_cp0_get_reg_fast(cpu,cp0_reg);
 }
 
 /* DMTC0 */
-fastcall void mips64_cp0_exec_dmtc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
+void mips64_cp0_exec_dmtc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
 {
    mips64_cp0_set_reg(cpu,cp0_reg,cpu->gpr[gp_reg]);
 }
 
 /* MFC0 */
-fastcall void mips64_cp0_exec_mfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
+void mips64_cp0_exec_mfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
 {
    cpu->gpr[gp_reg] = sign_extend(mips64_cp0_get_reg_fast(cpu,cp0_reg),32);
 }
 
 /* MTC0 */
-fastcall void mips64_cp0_exec_mtc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
+void mips64_cp0_exec_mtc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
 {
    mips64_cp0_set_reg(cpu,cp0_reg,cpu->gpr[gp_reg] & 0xffffffff);
 }
 
 /* CFC0 */
-fastcall void mips64_cp0_exec_cfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
+void mips64_cp0_exec_cfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
 {
    cpu->gpr[gp_reg] = sign_extend(mips64_cp0_s1_get_reg(cpu,cp0_reg),32);
 }
 
 /* CTC0 */
-fastcall void mips64_cp0_exec_ctc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
+void mips64_cp0_exec_ctc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg)
 {
    mips64_cp0_s1_set_reg(cpu,cp0_reg,cpu->gpr[gp_reg] & 0xffffffff);
 }

--- a/unstable/mips64_cp0.c
+++ b/unstable/mips64_cp0.c
@@ -470,7 +470,7 @@ void mips64_cp0_exec_tlbp(cpu_mips_t *cpu)
 }
 
 /* TLBR: Read Indexed TLB entry */
-fastcall void mips64_cp0_exec_tlbr(cpu_mips_t *cpu)
+void mips64_cp0_exec_tlbr(cpu_mips_t *cpu)
 {
    mips_cp0_t *cp0 = &cpu->cp0;
    tlb_entry_t *entry;

--- a/unstable/mips64_cp0.h
+++ b/unstable/mips64_cp0.h
@@ -104,7 +104,7 @@ void mips64_cp0_exec_tlbr(cpu_mips_t *cpu);
 void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu);
 
 /* TLBWR: Write Random TLB entry */
-fastcall void mips64_cp0_exec_tlbwr(cpu_mips_t *cpu);
+void mips64_cp0_exec_tlbwr(cpu_mips_t *cpu);
 
 /* Raw dump of the TLB */
 void mips64_tlb_raw_dump(cpu_gen_t *cpu);

--- a/unstable/mips64_cp0.h
+++ b/unstable/mips64_cp0.h
@@ -95,7 +95,7 @@ int mips64_cp0_tlb_lookup(cpu_mips_t *cpu,m_uint64_t vaddr,u_int op_type,
                           mts_map_t *res);
 
 /* TLBP: Probe a TLB entry */
-fastcall void mips64_cp0_exec_tlbp(cpu_mips_t *cpu);
+void mips64_cp0_exec_tlbp(cpu_mips_t *cpu);
 
 /* TLBR: Read Indexed TLB entry */
 fastcall void mips64_cp0_exec_tlbr(cpu_mips_t *cpu);

--- a/unstable/mips64_cp0.h
+++ b/unstable/mips64_cp0.h
@@ -71,24 +71,24 @@ u_int mips64_cp0_get_mode(cpu_mips_t *cpu);
 m_uint64_t mips64_cp0_get_reg(cpu_mips_t *cpu,u_int cp0_reg);
 
 /* DMFC0 */
-fastcall void mips64_cp0_exec_dmfc0(cpu_mips_t *cpu,u_int gp_reg,
+void mips64_cp0_exec_dmfc0(cpu_mips_t *cpu,u_int gp_reg,
                                     u_int cp0_reg);
 
 /* DMTC0 */
-fastcall void mips64_cp0_exec_dmtc0(cpu_mips_t *cpu,u_int gp_reg,
+void mips64_cp0_exec_dmtc0(cpu_mips_t *cpu,u_int gp_reg,
                                     u_int cp0_reg);
 
 /* MFC0 */
-fastcall void mips64_cp0_exec_mfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
+void mips64_cp0_exec_mfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
 
 /* MTC0 */
-fastcall void mips64_cp0_exec_mtc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
+void mips64_cp0_exec_mtc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
 
 /* CFC0 */
-fastcall void mips64_cp0_exec_cfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
+void mips64_cp0_exec_cfc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
 
 /* CTC0 */
-fastcall void mips64_cp0_exec_ctc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
+void mips64_cp0_exec_ctc0(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg);
 
 /* TLB lookup */
 int mips64_cp0_tlb_lookup(cpu_mips_t *cpu,m_uint64_t vaddr,u_int op_type,

--- a/unstable/mips64_cp0.h
+++ b/unstable/mips64_cp0.h
@@ -98,7 +98,7 @@ int mips64_cp0_tlb_lookup(cpu_mips_t *cpu,m_uint64_t vaddr,u_int op_type,
 void mips64_cp0_exec_tlbp(cpu_mips_t *cpu);
 
 /* TLBR: Read Indexed TLB entry */
-fastcall void mips64_cp0_exec_tlbr(cpu_mips_t *cpu);
+void mips64_cp0_exec_tlbr(cpu_mips_t *cpu);
 
 /* TLBWI: Write Indexed TLB entry */
 fastcall void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu);

--- a/unstable/mips64_cp0.h
+++ b/unstable/mips64_cp0.h
@@ -101,7 +101,7 @@ void mips64_cp0_exec_tlbp(cpu_mips_t *cpu);
 void mips64_cp0_exec_tlbr(cpu_mips_t *cpu);
 
 /* TLBWI: Write Indexed TLB entry */
-fastcall void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu);
+void mips64_cp0_exec_tlbwi(cpu_mips_t *cpu);
 
 /* TLBWR: Write Random TLB entry */
 fastcall void mips64_cp0_exec_tlbwr(cpu_mips_t *cpu);

--- a/unstable/mips64_exec.c
+++ b/unstable/mips64_exec.c
@@ -298,7 +298,7 @@ _Unused static forced_inline void mips64_exec_memop(cpu_mips_t *cpu,int memop,
                                             m_uint64_t vaddr,u_int dst_reg,
                                             int keep_ll_bit)
 {     
-   fastcall mips_memop_fn fn;
+   mips_memop_fn fn;
 
    if (!keep_ll_bit) cpu->ll_bit = 0;
    fn = cpu->mem_op_fn[memop];
@@ -311,7 +311,7 @@ static forced_inline void mips64_exec_memop2(cpu_mips_t *cpu,int memop,
                                              u_int dst_reg,int keep_ll_bit)
 {
    m_uint64_t vaddr = cpu->gpr[base] + sign_extend(offset,16);
-   fastcall mips_memop_fn fn;
+   mips_memop_fn fn;
       
    if (!keep_ll_bit) cpu->ll_bit = 0;
    fn = cpu->mem_op_fn[memop];

--- a/unstable/mips64_exec.c
+++ b/unstable/mips64_exec.c
@@ -392,7 +392,7 @@ void mips64_exec_single_step(cpu_mips_t *cpu,mips_insn_t instruction)
 }
 
 /* Execute a page */
-fastcall int mips64_exec_page(cpu_mips_t *cpu)
+int mips64_exec_page(cpu_mips_t *cpu)
 {
    m_uint32_t offset;
    mips_insn_t insn;

--- a/unstable/mips64_exec.c
+++ b/unstable/mips64_exec.c
@@ -381,7 +381,7 @@ mips64_exec_single_instruction(cpu_mips_t *cpu,mips_insn_t instruction)
 }
 
 /* Single-step execution */
-fastcall void mips64_exec_single_step(cpu_mips_t *cpu,mips_insn_t instruction)
+void mips64_exec_single_step(cpu_mips_t *cpu,mips_insn_t instruction)
 {
    int res;
 

--- a/unstable/mips64_exec.c
+++ b/unstable/mips64_exec.c
@@ -338,7 +338,7 @@ static forced_inline int mips64_exec_fetch(cpu_mips_t *cpu,m_uint64_t pc,
 }
 
 /* Unknown opcode */
-static fastcall int mips64_exec_unknown(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_unknown(cpu_mips_t *cpu,mips_insn_t insn)
 {
    printf("MIPS64: unknown opcode 0x%8.8x at pc = 0x%llx\n",insn,cpu->pc);
    mips64_dump_regs(cpu->gen);
@@ -349,7 +349,7 @@ static fastcall int mips64_exec_unknown(cpu_mips_t *cpu,mips_insn_t insn)
 static forced_inline int 
 mips64_exec_single_instruction(cpu_mips_t *cpu,mips_insn_t instruction)
 {
-   register fastcall int (*exec)(cpu_mips_t *,mips_insn_t) = NULL;
+   register int (*exec)(cpu_mips_t *,mips_insn_t) = NULL;
    struct mips64_insn_exec_tag *tag;
    int index;
 
@@ -529,7 +529,7 @@ static forced_inline void mips64_exec_bdslot(cpu_mips_t *cpu)
 }
 
 /* ADD */
-static fastcall int mips64_exec_ADD(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ADD(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -543,7 +543,7 @@ static fastcall int mips64_exec_ADD(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* ADDI */
-static fastcall int mips64_exec_ADDI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ADDI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -557,7 +557,7 @@ static fastcall int mips64_exec_ADDI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* ADDIU */
-static fastcall int mips64_exec_ADDIU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ADDIU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -570,7 +570,7 @@ static fastcall int mips64_exec_ADDIU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* ADDU */
-static fastcall int mips64_exec_ADDU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ADDU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -583,7 +583,7 @@ static fastcall int mips64_exec_ADDU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* AND */
-static fastcall int mips64_exec_AND(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_AND(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -594,7 +594,7 @@ static fastcall int mips64_exec_AND(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* ANDI */
-static fastcall int mips64_exec_ANDI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ANDI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs  = bits(insn,21,25);
    int rt  = bits(insn,16,20);
@@ -605,7 +605,7 @@ static fastcall int mips64_exec_ANDI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* B (Branch, virtual instruction) */
-static fastcall int mips64_exec_B(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_B(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int offset = bits(insn,0,15);
    m_uint64_t new_pc;
@@ -622,7 +622,7 @@ static fastcall int mips64_exec_B(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BAL (Branch And Link, virtual instruction) */
-static fastcall int mips64_exec_BAL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BAL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int offset = bits(insn,0,15);
    m_uint64_t new_pc;
@@ -642,7 +642,7 @@ static fastcall int mips64_exec_BAL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BEQ (Branch On Equal) */
-static fastcall int mips64_exec_BEQ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BEQ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -669,7 +669,7 @@ static fastcall int mips64_exec_BEQ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BEQL (Branch On Equal Likely) */
-static fastcall int mips64_exec_BEQL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BEQL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -694,7 +694,7 @@ static fastcall int mips64_exec_BEQL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BEQZ (Branch On Equal Zero) - Virtual Instruction */
-static fastcall int mips64_exec_BEQZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BEQZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -720,7 +720,7 @@ static fastcall int mips64_exec_BEQZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BNEZ (Branch On Not Equal Zero) - Virtual Instruction */
-static fastcall int mips64_exec_BNEZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BNEZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -746,7 +746,7 @@ static fastcall int mips64_exec_BNEZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BGEZ (Branch On Greater or Equal Than Zero) */
-static fastcall int mips64_exec_BGEZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BGEZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -772,7 +772,7 @@ static fastcall int mips64_exec_BGEZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BGEZAL (Branch On Greater or Equal Than Zero And Link) */
-static fastcall int mips64_exec_BGEZAL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BGEZAL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -801,7 +801,7 @@ static fastcall int mips64_exec_BGEZAL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BGEZALL (Branch On Greater or Equal Than Zero And Link Likely) */
-static fastcall int mips64_exec_BGEZALL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BGEZALL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -828,7 +828,7 @@ static fastcall int mips64_exec_BGEZALL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BGEZL (Branch On Greater or Equal Than Zero Likely) */
-static fastcall int mips64_exec_BGEZL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BGEZL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -852,7 +852,7 @@ static fastcall int mips64_exec_BGEZL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BGTZ (Branch On Greater Than Zero) */
-static fastcall int mips64_exec_BGTZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BGTZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -878,7 +878,7 @@ static fastcall int mips64_exec_BGTZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BGTZL (Branch On Greater Than Zero Likely) */
-static fastcall int mips64_exec_BGTZL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BGTZL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -902,7 +902,7 @@ static fastcall int mips64_exec_BGTZL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BLEZ (Branch On Less or Equal Than Zero) */
-static fastcall int mips64_exec_BLEZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BLEZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -928,7 +928,7 @@ static fastcall int mips64_exec_BLEZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BLEZL (Branch On Less or Equal Than Zero Likely) */
-static fastcall int mips64_exec_BLEZL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BLEZL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -952,7 +952,7 @@ static fastcall int mips64_exec_BLEZL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BLTZ (Branch On Less Than Zero) */
-static fastcall int mips64_exec_BLTZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BLTZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -978,7 +978,7 @@ static fastcall int mips64_exec_BLTZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BLTZAL (Branch On Less Than Zero And Link) */
-static fastcall int mips64_exec_BLTZAL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BLTZAL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -1007,7 +1007,7 @@ static fastcall int mips64_exec_BLTZAL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BLTZALL (Branch On Less Than Zero And Link Likely) */
-static fastcall int mips64_exec_BLTZALL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BLTZALL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -1034,7 +1034,7 @@ static fastcall int mips64_exec_BLTZALL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BLTZL (Branch On Less Than Zero Likely) */
-static fastcall int mips64_exec_BLTZL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BLTZL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int offset = bits(insn,0,15);
@@ -1058,7 +1058,7 @@ static fastcall int mips64_exec_BLTZL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BNE (Branch On Not Equal) */
-static fastcall int mips64_exec_BNE(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BNE(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1085,7 +1085,7 @@ static fastcall int mips64_exec_BNE(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BNEL (Branch On Not Equal Likely) */
-static fastcall int mips64_exec_BNEL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BNEL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1110,7 +1110,7 @@ static fastcall int mips64_exec_BNEL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* BREAK */
-static fastcall int mips64_exec_BREAK(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_BREAK(cpu_mips_t *cpu,mips_insn_t insn)
 {
    u_int code = bits(insn,6,25);
 
@@ -1119,7 +1119,7 @@ static fastcall int mips64_exec_BREAK(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* CACHE */
-static fastcall int mips64_exec_CACHE(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_CACHE(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int op     = bits(insn,16,20);
@@ -1130,7 +1130,7 @@ static fastcall int mips64_exec_CACHE(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* CFC0 */
-static fastcall int mips64_exec_CFC0(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_CFC0(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1140,7 +1140,7 @@ static fastcall int mips64_exec_CFC0(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* CTC0 */
-static fastcall int mips64_exec_CTC0(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_CTC0(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1150,7 +1150,7 @@ static fastcall int mips64_exec_CTC0(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DADDIU */
-static fastcall int mips64_exec_DADDIU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DADDIU(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rs  = bits(insn,21,25);
    int rt  = bits(insn,16,20);
@@ -1162,7 +1162,7 @@ static fastcall int mips64_exec_DADDIU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DADDU: rd = rs + rt */
-static fastcall int mips64_exec_DADDU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DADDU(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1173,7 +1173,7 @@ static fastcall int mips64_exec_DADDU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DIV */
-static fastcall int mips64_exec_DIV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DIV(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1187,7 +1187,7 @@ static fastcall int mips64_exec_DIV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DIVU */
-static fastcall int mips64_exec_DIVU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DIVU(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1204,7 +1204,7 @@ static fastcall int mips64_exec_DIVU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DMFC0 */
-static fastcall int mips64_exec_DMFC0(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DMFC0(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1214,7 +1214,7 @@ static fastcall int mips64_exec_DMFC0(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DMFC1 */
-static fastcall int mips64_exec_DMFC1(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DMFC1(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1224,7 +1224,7 @@ static fastcall int mips64_exec_DMFC1(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DMTC0 */
-static fastcall int mips64_exec_DMTC0(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DMTC0(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1234,7 +1234,7 @@ static fastcall int mips64_exec_DMTC0(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DMTC1 */
-static fastcall int mips64_exec_DMTC1(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DMTC1(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1244,7 +1244,7 @@ static fastcall int mips64_exec_DMTC1(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSLL */
-static fastcall int mips64_exec_DSLL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSLL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1255,7 +1255,7 @@ static fastcall int mips64_exec_DSLL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSLL32 */
-static fastcall int mips64_exec_DSLL32(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSLL32(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1266,7 +1266,7 @@ static fastcall int mips64_exec_DSLL32(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSLLV */
-static fastcall int mips64_exec_DSLLV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSLLV(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1277,7 +1277,7 @@ static fastcall int mips64_exec_DSLLV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSRA */
-static fastcall int mips64_exec_DSRA(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSRA(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1288,7 +1288,7 @@ static fastcall int mips64_exec_DSRA(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSRA32 */
-static fastcall int mips64_exec_DSRA32(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSRA32(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1299,7 +1299,7 @@ static fastcall int mips64_exec_DSRA32(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSRAV */
-static fastcall int mips64_exec_DSRAV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSRAV(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1310,7 +1310,7 @@ static fastcall int mips64_exec_DSRAV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSRL */
-static fastcall int mips64_exec_DSRL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSRL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1321,7 +1321,7 @@ static fastcall int mips64_exec_DSRL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSRL32 */
-static fastcall int mips64_exec_DSRL32(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSRL32(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1332,7 +1332,7 @@ static fastcall int mips64_exec_DSRL32(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSRLV */
-static fastcall int mips64_exec_DSRLV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSRLV(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1343,7 +1343,7 @@ static fastcall int mips64_exec_DSRLV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* DSUBU */
-static fastcall int mips64_exec_DSUBU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_DSUBU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1354,14 +1354,14 @@ static fastcall int mips64_exec_DSUBU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* ERET */
-static fastcall int mips64_exec_ERET(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ERET(cpu_mips_t *cpu,mips_insn_t insn)
 {
    mips64_exec_eret(cpu);
    return(1);
 }
 
 /* J */
-static fastcall int mips64_exec_J(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_J(cpu_mips_t *cpu,mips_insn_t insn)
 {
    u_int instr_index = bits(insn,0,25);
    m_uint64_t new_pc;
@@ -1379,7 +1379,7 @@ static fastcall int mips64_exec_J(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* JAL */
-static fastcall int mips64_exec_JAL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_JAL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    u_int instr_index = bits(insn,0,25);
    m_uint64_t new_pc;
@@ -1400,7 +1400,7 @@ static fastcall int mips64_exec_JAL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* JALR */
-static fastcall int mips64_exec_JALR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_JALR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rd = bits(insn,11,15);
@@ -1421,7 +1421,7 @@ static fastcall int mips64_exec_JALR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* JR */
-static fastcall int mips64_exec_JR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_JR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    m_uint64_t new_pc;
@@ -1438,7 +1438,7 @@ static fastcall int mips64_exec_JR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LB (Load Byte) */
-static fastcall int mips64_exec_LB(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LB(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1449,7 +1449,7 @@ static fastcall int mips64_exec_LB(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LBU (Load Byte Unsigned) */
-static fastcall int mips64_exec_LBU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LBU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1460,7 +1460,7 @@ static fastcall int mips64_exec_LBU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LD (Load Double-Word) */
-static fastcall int mips64_exec_LD(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LD(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1471,7 +1471,7 @@ static fastcall int mips64_exec_LD(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LDC1 (Load Double-Word to Coprocessor 1) */
-static fastcall int mips64_exec_LDC1(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LDC1(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int ft     = bits(insn,16,20);
@@ -1482,7 +1482,7 @@ static fastcall int mips64_exec_LDC1(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LDL (Load Double-Word Left) */
-static fastcall int mips64_exec_LDL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LDL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1493,7 +1493,7 @@ static fastcall int mips64_exec_LDL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LDR (Load Double-Word Right) */
-static fastcall int mips64_exec_LDR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LDR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1504,7 +1504,7 @@ static fastcall int mips64_exec_LDR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LH (Load Half-Word) */
-static fastcall int mips64_exec_LH(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LH(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1515,7 +1515,7 @@ static fastcall int mips64_exec_LH(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LHU (Load Half-Word Unsigned) */
-static fastcall int mips64_exec_LHU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LHU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1526,7 +1526,7 @@ static fastcall int mips64_exec_LHU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LI (virtual) */
-static fastcall int mips64_exec_LI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt  = bits(insn,16,20);
    int imm = bits(insn,0,15);
@@ -1536,7 +1536,7 @@ static fastcall int mips64_exec_LI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LL (Load Linked) */
-static fastcall int mips64_exec_LL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1547,7 +1547,7 @@ static fastcall int mips64_exec_LL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LUI */
-static fastcall int mips64_exec_LUI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LUI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt  = bits(insn,16,20);
    int imm = bits(insn,0,15);
@@ -1557,7 +1557,7 @@ static fastcall int mips64_exec_LUI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LW (Load Word) */
-static fastcall int mips64_exec_LW(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LW(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1568,7 +1568,7 @@ static fastcall int mips64_exec_LW(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LWL (Load Word Left) */
-static fastcall int mips64_exec_LWL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LWL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1579,7 +1579,7 @@ static fastcall int mips64_exec_LWL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LWR (Load Word Right) */
-static fastcall int mips64_exec_LWR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LWR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1590,7 +1590,7 @@ static fastcall int mips64_exec_LWR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* LWU (Load Word Unsigned) */
-static fastcall int mips64_exec_LWU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_LWU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1601,7 +1601,7 @@ static fastcall int mips64_exec_LWU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MFC0 */
-static fastcall int mips64_exec_MFC0(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MFC0(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1611,7 +1611,7 @@ static fastcall int mips64_exec_MFC0(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MFC1 */
-static fastcall int mips64_exec_MFC1(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MFC1(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1621,7 +1621,7 @@ static fastcall int mips64_exec_MFC1(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MFHI */
-static fastcall int mips64_exec_MFHI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MFHI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rd = bits(insn,11,15);
 
@@ -1630,7 +1630,7 @@ static fastcall int mips64_exec_MFHI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MFLO */
-static fastcall int mips64_exec_MFLO(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MFLO(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rd = bits(insn,11,15);
 
@@ -1639,7 +1639,7 @@ static fastcall int mips64_exec_MFLO(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MOVE (virtual instruction, real: ADDU) */
-static fastcall int mips64_exec_MOVE(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MOVE(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rd = bits(insn,11,15);
@@ -1649,7 +1649,7 @@ static fastcall int mips64_exec_MOVE(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MOVZ */
-static fastcall int mips64_exec_MOVZ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MOVZ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1662,7 +1662,7 @@ static fastcall int mips64_exec_MOVZ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MTC0 */
-static fastcall int mips64_exec_MTC0(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MTC0(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1672,7 +1672,7 @@ static fastcall int mips64_exec_MTC0(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MTC1 */
-static fastcall int mips64_exec_MTC1(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MTC1(cpu_mips_t *cpu,mips_insn_t insn)
 {	
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1682,7 +1682,7 @@ static fastcall int mips64_exec_MTC1(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MTHI */
-static fastcall int mips64_exec_MTHI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MTHI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
 
@@ -1691,7 +1691,7 @@ static fastcall int mips64_exec_MTHI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MTLO */
-static fastcall int mips64_exec_MTLO(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MTLO(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
 
@@ -1700,7 +1700,7 @@ static fastcall int mips64_exec_MTLO(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MUL */
-static fastcall int mips64_exec_MUL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MUL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1714,7 +1714,7 @@ static fastcall int mips64_exec_MUL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MULT */
-static fastcall int mips64_exec_MULT(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MULT(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1729,7 +1729,7 @@ static fastcall int mips64_exec_MULT(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* MULTU */
-static fastcall int mips64_exec_MULTU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_MULTU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1743,13 +1743,13 @@ static fastcall int mips64_exec_MULTU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* NOP */
-static fastcall int mips64_exec_NOP(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_NOP(cpu_mips_t *cpu,mips_insn_t insn)
 {
    return(0);
 }
 
 /* NOR */
-static fastcall int mips64_exec_NOR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_NOR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1760,7 +1760,7 @@ static fastcall int mips64_exec_NOR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* OR */
-static fastcall int mips64_exec_OR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_OR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1771,7 +1771,7 @@ static fastcall int mips64_exec_OR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* ORI */
-static fastcall int mips64_exec_ORI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_ORI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs  = bits(insn,21,25);
    int rt  = bits(insn,16,20);
@@ -1782,19 +1782,19 @@ static fastcall int mips64_exec_ORI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* PREF */
-static fastcall int mips64_exec_PREF(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_PREF(cpu_mips_t *cpu,mips_insn_t insn)
 {
    return(0);
 }
 
 /* PREFI */
-static fastcall int mips64_exec_PREFI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_PREFI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    return(0);
 }
 
 /* SB (Store Byte) */
-static fastcall int mips64_exec_SB(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SB(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1805,7 +1805,7 @@ static fastcall int mips64_exec_SB(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SC (Store Conditional) */
-static fastcall int mips64_exec_SC(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SC(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1816,7 +1816,7 @@ static fastcall int mips64_exec_SC(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SD (Store Double-Word) */
-static fastcall int mips64_exec_SD(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SD(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1827,7 +1827,7 @@ static fastcall int mips64_exec_SD(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SDL (Store Double-Word Left) */
-static fastcall int mips64_exec_SDL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SDL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1838,7 +1838,7 @@ static fastcall int mips64_exec_SDL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SDR (Store Double-Word Right) */
-static fastcall int mips64_exec_SDR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SDR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1849,7 +1849,7 @@ static fastcall int mips64_exec_SDR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SDC1 (Store Double-Word from Coprocessor 1) */
-static fastcall int mips64_exec_SDC1(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SDC1(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int ft     = bits(insn,16,20);
@@ -1860,7 +1860,7 @@ static fastcall int mips64_exec_SDC1(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SH (Store Half-Word) */
-static fastcall int mips64_exec_SH(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SH(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -1871,7 +1871,7 @@ static fastcall int mips64_exec_SH(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SLL */
-static fastcall int mips64_exec_SLL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SLL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1884,7 +1884,7 @@ static fastcall int mips64_exec_SLL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SLLV */
-static fastcall int mips64_exec_SLLV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SLLV(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1897,7 +1897,7 @@ static fastcall int mips64_exec_SLLV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SLT */
-static fastcall int mips64_exec_SLT(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SLT(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1912,7 +1912,7 @@ static fastcall int mips64_exec_SLT(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SLTI */
-static fastcall int mips64_exec_SLTI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SLTI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1928,7 +1928,7 @@ static fastcall int mips64_exec_SLTI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SLTIU */
-static fastcall int mips64_exec_SLTIU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SLTIU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1944,7 +1944,7 @@ static fastcall int mips64_exec_SLTIU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SLTU */
-static fastcall int mips64_exec_SLTU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SLTU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1959,7 +1959,7 @@ static fastcall int mips64_exec_SLTU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SRA */
-static fastcall int mips64_exec_SRA(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SRA(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1972,7 +1972,7 @@ static fastcall int mips64_exec_SRA(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SRAV */
-static fastcall int mips64_exec_SRAV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SRAV(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -1985,7 +1985,7 @@ static fastcall int mips64_exec_SRAV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SRL */
-static fastcall int mips64_exec_SRL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SRL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rt = bits(insn,16,20);
    int rd = bits(insn,11,15);
@@ -1998,7 +1998,7 @@ static fastcall int mips64_exec_SRL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SRLV */
-static fastcall int mips64_exec_SRLV(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SRLV(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -2011,7 +2011,7 @@ static fastcall int mips64_exec_SRLV(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SUB */
-static fastcall int mips64_exec_SUB(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SUB(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -2025,7 +2025,7 @@ static fastcall int mips64_exec_SUB(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SUBU */
-static fastcall int mips64_exec_SUBU(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SUBU(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -2038,7 +2038,7 @@ static fastcall int mips64_exec_SUBU(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SW (Store Word) */
-static fastcall int mips64_exec_SW(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SW(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -2049,7 +2049,7 @@ static fastcall int mips64_exec_SW(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SWL (Store Word Left) */
-static fastcall int mips64_exec_SWL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SWL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -2060,7 +2060,7 @@ static fastcall int mips64_exec_SWL(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SWR (Store Word Right) */
-static fastcall int mips64_exec_SWR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SWR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int base   = bits(insn,21,25);
    int rt     = bits(insn,16,20);
@@ -2071,20 +2071,20 @@ static fastcall int mips64_exec_SWR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* SYNC */
-static fastcall int mips64_exec_SYNC(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SYNC(cpu_mips_t *cpu,mips_insn_t insn)
 {
    return(0);
 }
 
 /* SYSCALL */
-static fastcall int mips64_exec_SYSCALL(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_SYSCALL(cpu_mips_t *cpu,mips_insn_t insn)
 {
    mips64_exec_syscall(cpu);
    return(1);
 }
 
 /* TEQ (Trap if Equal) */
-static fastcall int mips64_exec_TEQ(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_TEQ(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -2098,7 +2098,7 @@ static fastcall int mips64_exec_TEQ(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* TEQI (Trap if Equal Immediate) */
-static fastcall int mips64_exec_TEQI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_TEQI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int imm = bits(insn,0,15);
@@ -2113,35 +2113,35 @@ static fastcall int mips64_exec_TEQI(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* TLBP */
-static fastcall int mips64_exec_TLBP(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_TLBP(cpu_mips_t *cpu,mips_insn_t insn)
 {
    mips64_cp0_exec_tlbp(cpu);
    return(0);
 }
 
 /* TLBR */
-static fastcall int mips64_exec_TLBR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_TLBR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    mips64_cp0_exec_tlbr(cpu);
    return(0);
 }
 
 /* TLBWI */
-static fastcall int mips64_exec_TLBWI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_TLBWI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    mips64_cp0_exec_tlbwi(cpu);
    return(0);
 }
 
 /* TLBWR */
-static fastcall int mips64_exec_TLBWR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_TLBWR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    mips64_cp0_exec_tlbwr(cpu);
    return(0);
 }
 
 /* XOR */
-static fastcall int mips64_exec_XOR(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_XOR(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int rt = bits(insn,16,20);
@@ -2152,7 +2152,7 @@ static fastcall int mips64_exec_XOR(cpu_mips_t *cpu,mips_insn_t insn)
 }
 
 /* XORI */
-static fastcall int mips64_exec_XORI(cpu_mips_t *cpu,mips_insn_t insn)
+static int mips64_exec_XORI(cpu_mips_t *cpu,mips_insn_t insn)
 {
    int rs  = bits(insn,21,25);
    int rt  = bits(insn,16,20);

--- a/unstable/mips64_exec.h
+++ b/unstable/mips64_exec.h
@@ -33,7 +33,7 @@ void mips64_dump_insn_block(cpu_mips_t *cpu,m_uint64_t pc,u_int count,
                             size_t insn_name_size);
 
 /* Single-step execution */
-fastcall void mips64_exec_single_step(cpu_mips_t *cpu,mips_insn_t instruction);
+void mips64_exec_single_step(cpu_mips_t *cpu,mips_insn_t instruction);
 
 /* Execute a page */
 fastcall int mips64_exec_page(cpu_mips_t *cpu);

--- a/unstable/mips64_exec.h
+++ b/unstable/mips64_exec.h
@@ -36,7 +36,7 @@ void mips64_dump_insn_block(cpu_mips_t *cpu,m_uint64_t pc,u_int count,
 void mips64_exec_single_step(cpu_mips_t *cpu,mips_insn_t instruction);
 
 /* Execute a page */
-fastcall int mips64_exec_page(cpu_mips_t *cpu);
+int mips64_exec_page(cpu_mips_t *cpu);
 
 /* Run MIPS code in step-by-step mode */
 void *mips64_exec_run_cpu(cpu_gen_t *cpu);

--- a/unstable/mips64_exec.h
+++ b/unstable/mips64_exec.h
@@ -11,7 +11,7 @@
 /* MIPS instruction recognition */
 struct mips64_insn_exec_tag {
    char *name;
-   fastcall int (*exec)(cpu_mips_t *,mips_insn_t);
+   int (*exec)(cpu_mips_t *,mips_insn_t);
    m_uint32_t mask,value;
    int delay_slot;
    int instr_type;

--- a/unstable/mips64_mem.c
+++ b/unstable/mips64_mem.c
@@ -328,7 +328,7 @@ void *mips64_mts64_access(cpu_mips_t *cpu,m_uint64_t vaddr,
 }
 
 /* MTS64 virtual address to physical page translation */
-static fastcall int mips64_mts64_translate(cpu_mips_t *cpu,m_uint64_t vaddr,
+static int mips64_mts64_translate(cpu_mips_t *cpu,m_uint64_t vaddr,
                                            m_uint32_t *phys_page)
 {   
    mts64_entry_t *entry,alt_entry;
@@ -492,7 +492,7 @@ void *mips64_mts32_access(cpu_mips_t *cpu,m_uint64_t vaddr,
 }
 
 /* MTS32 virtual address to physical page translation */
-static fastcall int mips64_mts32_translate(cpu_mips_t *cpu,m_uint64_t vaddr,
+static int mips64_mts32_translate(cpu_mips_t *cpu,m_uint64_t vaddr,
                                            m_uint32_t *phys_page)
 {     
    mts32_entry_t *entry,alt_entry;

--- a/unstable/mips64_ppc32_trans.c
+++ b/unstable/mips64_ppc32_trans.c
@@ -565,7 +565,7 @@ static int mips64_emit_unknown(cpu_mips_t *cpu,mips64_jit_tcb_t *b,
 }
 
 /* Invalid delay slot handler */
-static fastcall void mips64_invalid_delay_slot(cpu_mips_t *cpu)
+static void mips64_invalid_delay_slot(cpu_mips_t *cpu)
 {
    printf("MIPS64: invalid instruction in delay slot at 0x%llx (ra=0x%llx)\n",
           cpu->pc,cpu->gpr[MIPS_GPR_RA]);

--- a/unstable/mips64_ppc32_trans.c
+++ b/unstable/mips64_ppc32_trans.c
@@ -525,7 +525,7 @@ static void mips64_emit_memop(mips64_jit_tcb_t *b,int opcode,int base,int offset
 }
 
 /* Coprocessor Register transfert operation */
-static void mips64_emit_cp_xfr_op(mips64_jit_tcb_t *b,int rt,int rd,void *f)
+static void mips64_emit_cp_xfr_op(mips64_jit_tcb_t *b,int rt,int rd,void (*f)(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg))
 {
    /* update pc */
    mips64_set_pc(b,b->start_pc+((b->mips_trans_pos-1)<<2));

--- a/unstable/mips64_ppc32_trans.c
+++ b/unstable/mips64_ppc32_trans.c
@@ -547,7 +547,7 @@ void mips64_emit_breakpoint(mips64_jit_tcb_t *b)
 }
 
 /* Unknown opcode handler */
-static asmlinkage void mips64_unknown_opcode(cpu_mips_t *cpu,m_uint32_t opcode)
+static void mips64_unknown_opcode(cpu_mips_t *cpu,m_uint32_t opcode)
 {
    printf("MIPS64: unhandled opcode 0x%8.8x at 0x%llx (ra=0x%llx)\n",
           opcode,cpu->pc,cpu->gpr[MIPS_GPR_RA]);

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -535,7 +535,7 @@ static int mips64_emit_unknown(cpu_mips_t *cpu,cpu_tc_t *b,
 }
 
 /* Invalid delay slot handler */
-static fastcall void mips64_invalid_delay_slot(cpu_mips_t *cpu)
+static void mips64_invalid_delay_slot(cpu_mips_t *cpu)
 {
    printf("MIPS64: invalid instruction in delay slot at 0x%llx (ra=0x%llx)\n",
           cpu->pc,cpu->gpr[MIPS_GPR_RA]);
@@ -549,8 +549,9 @@ static fastcall void mips64_invalid_delay_slot(cpu_mips_t *cpu)
 /* Emit unhandled instruction code */
 int mips64_emit_invalid_delay_slot(cpu_tc_t *b)
 {   
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_c_call(b,mips64_invalid_delay_slot);
    x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -513,7 +513,7 @@ void mips64_emit_breakpoint(cpu_tc_t *b)
 }
 
 /* Unknown opcode handler */
-static asmlinkage void mips64_unknown_opcode(cpu_mips_t *cpu,m_uint32_t opcode)
+static void mips64_unknown_opcode(cpu_mips_t *cpu,m_uint32_t opcode)
 {
    printf("MIPS64: unhandled opcode 0x%8.8x at 0x%llx (ra=0x%llx)\n",
           opcode,cpu->pc,cpu->gpr[MIPS_GPR_RA]);

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -2838,7 +2838,10 @@ DECLARE_INSN(SYSCALL)
    mips64_set_pc(b,b->vaddr+((b->trans_pos-1)<<2));
 
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_exec_syscall);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
 
    mips64_jit_tcb_push_epilog(b);
    return(0);

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -490,7 +490,7 @@ static void mips64_emit_memop(cpu_tc_t *b,int op,int base,int offset,
 }
 
 /* Coprocessor Register transfert operation */
-static void mips64_emit_cp_xfr_op(cpu_tc_t *b,int rt,int rd,void *f)
+static void mips64_emit_cp_xfr_op(cpu_tc_t *b,int rt,int rd,void (*f)(cpu_mips_t *cpu,u_int gp_reg,u_int cp0_reg))
 {
    /* update pc */
    mips64_set_pc(b,b->vaddr+((b->trans_pos-1)<<2));
@@ -504,7 +504,12 @@ static void mips64_emit_cp_xfr_op(cpu_tc_t *b,int rt,int rd,void *f)
    /* cpu instance */
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
 
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,0);
+   x86_push_reg(b->jit_ptr,X86_ECX);
+   x86_push_reg(b->jit_ptr,X86_EDX);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,f);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
 }
 
 /* Virtual Breakpoint */

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -2940,7 +2940,10 @@ DECLARE_INSN(TLBWI)
 {   
    mips64_set_pc(b,b->vaddr+((b->trans_pos-1)<<2));
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_cp0_exec_tlbwi);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    return(0);
 }
 

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -1424,9 +1424,11 @@ DECLARE_INSN(BREAK)
 {	
    u_int code = bits(insn,6,25);
 
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_mov_reg_imm(b->jit_ptr,X86_EDX,code);
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,4);
+   x86_push_reg(b->jit_ptr,X86_EDX);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_exec_break);
    x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
 

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -594,7 +594,10 @@ void mips64_check_pending_irq(cpu_tc_t *b)
 
    /* Trigger the IRQ */
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_trigger_irq);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    mips64_jit_tcb_push_epilog(b);
 
    x86_patch(test1,b->jit_ptr);

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -2952,7 +2952,10 @@ DECLARE_INSN(TLBWR)
 {   
    mips64_set_pc(b,b->vaddr+((b->trans_pos-1)<<2));
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_cp0_exec_tlbwr);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    return(0);
 }
 

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -2928,7 +2928,10 @@ DECLARE_INSN(TLBR)
 {  
    mips64_set_pc(b,b->vaddr+((b->trans_pos-1)<<2));
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_cp0_exec_tlbr);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    return(0);
 }
 

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -2916,7 +2916,10 @@ DECLARE_INSN(TLBP)
 {
    mips64_set_pc(b,b->vaddr+((b->trans_pos-1)<<2));
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_cp0_exec_tlbp);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    return(0);
 }
 

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -322,14 +322,14 @@ static void mips64_emit_memop_fast64(cpu_tc_t *b,int write_op,
    /* EAX = CPU instance pointer */
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
 
-   /* 
-    * Push parameters on stack and call memory function.
-    * Keep the stack aligned on a 16-byte boundary for Darwin/x86.
-    */
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   /* Call memory function */
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_push_reg(b->jit_ptr,X86_EBX);
+   x86_push_reg(b->jit_ptr,X86_ECX);
+   x86_push_reg(b->jit_ptr,X86_EDX);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    x86_call_membase(b->jit_ptr,X86_EDI,MEMOP_OFFSET(opcode));
-   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12+16);
 
    x86_patch(p_exit,b->jit_ptr);
 }
@@ -416,14 +416,14 @@ static void mips64_emit_memop_fast32(cpu_tc_t *b,int write_op,
    /* EAX = CPU instance pointer */
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
 
-   /* 
-    * Push parameters on stack and call memory function.
-    * Keep the stack aligned on a 16-byte boundary for Darwin/x86.
-    */
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   /* Call memory function */
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_push_reg(b->jit_ptr,X86_EBX);
+   x86_push_reg(b->jit_ptr,X86_ECX);
+   x86_push_reg(b->jit_ptr,X86_EDX);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    x86_call_membase(b->jit_ptr,X86_EDI,MEMOP_OFFSET(opcode));
-   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12+16);
 
    x86_patch(p_exit,b->jit_ptr);
 }
@@ -475,14 +475,14 @@ static void mips64_emit_memop(cpu_tc_t *b,int op,int base,int offset,
    /* EAX = CPU instance pointer */
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
 
-   /* 
-    * Push parameters on stack and call memory function.
-    * Keep the stack aligned on a 16-byte boundary for Darwin/x86.
-    */
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   /* Call memory function */
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_push_reg(b->jit_ptr,X86_EBX);
+   x86_push_reg(b->jit_ptr,X86_ECX);
+   x86_push_reg(b->jit_ptr,X86_EDX);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    x86_call_membase(b->jit_ptr,X86_EDI,MEMOP_OFFSET(op));
-   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12+16);
 }
 
 /* Coprocessor Register transfert operation */

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -515,8 +515,9 @@ static void mips64_emit_cp_xfr_op(cpu_tc_t *b,int rt,int rd,void (*f)(cpu_mips_t
 /* Virtual Breakpoint */
 void mips64_emit_breakpoint(cpu_tc_t *b)
 {
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_c_call(b,mips64_run_breakpoint);
    x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
 }

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -212,7 +212,11 @@ void mips64_emit_single_step(cpu_tc_t *b,mips_insn_t insn)
 {
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
    x86_mov_reg_imm(b->jit_ptr,X86_EDX,insn);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,4);
+   x86_push_reg(b->jit_ptr,X86_EDX);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_exec_single_step);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
 }
 
 /* Fast memory operation prototype */

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -2869,8 +2869,9 @@ DECLARE_INSN(TEQ)
    x86_branch8(b->jit_ptr, X86_CC_NE, 0, 1);
 
    /* Generate trap exception */
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_c_call(b,mips64_trigger_trap_exception);
    x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    
@@ -2906,8 +2907,9 @@ DECLARE_INSN(TEQI)
    x86_branch8(b->jit_ptr, X86_CC_NE, 0, 1);
 
    /* Generate trap exception */
-   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,12);
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_c_call(b,mips64_trigger_trap_exception);
    x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
 

--- a/unstable/mips64_x86_trans.c
+++ b/unstable/mips64_x86_trans.c
@@ -1797,7 +1797,10 @@ DECLARE_INSN(ERET)
    mips64_set_pc(b,b->vaddr+((b->trans_pos-1)<<2));
 
    x86_mov_reg_reg(b->jit_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(b->jit_ptr,X86_SUB,X86_ESP,8);
+   x86_push_reg(b->jit_ptr,X86_EAX);
    mips64_emit_basic_c_call(b,mips64_exec_eret);
+   x86_alu_reg_imm(b->jit_ptr,X86_ADD,X86_ESP,12);
    mips64_jit_tcb_push_epilog(b);
    return(0);
 }

--- a/unstable/mips_mts.c
+++ b/unstable/mips_mts.c
@@ -13,7 +13,7 @@ static forced_inline void *MTS_PROTO(access)(cpu_mips_t *cpu,m_uint64_t vaddr,
                                              u_int op_code,u_int op_size,
                                              u_int op_type,m_uint64_t *data);
 
-static fastcall int MTS_PROTO(translate)(cpu_mips_t *cpu,m_uint64_t vaddr,
+static int MTS_PROTO(translate)(cpu_mips_t *cpu,m_uint64_t vaddr,
                                          m_uint32_t *phys_page);
 
 /* Initialize the MTS subsystem for the specified CPU */

--- a/unstable/mips_mts.c
+++ b/unstable/mips_mts.c
@@ -169,7 +169,7 @@ static void *MTS_PROTO(ifetch)(cpu_mips_t *cpu,m_uint64_t vaddr)
 /* === MIPS Memory Operations ============================================= */
 
 /* LB: Load Byte */
-fastcall void MTS_PROTO(lb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -180,7 +180,7 @@ fastcall void MTS_PROTO(lb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LBU: Load Byte Unsigned */
-fastcall void MTS_PROTO(lbu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lbu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -191,7 +191,7 @@ fastcall void MTS_PROTO(lbu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LH: Load Half-Word */
-fastcall void MTS_PROTO(lh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -202,7 +202,7 @@ fastcall void MTS_PROTO(lh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LHU: Load Half-Word Unsigned */
-fastcall void MTS_PROTO(lhu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lhu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -213,7 +213,7 @@ fastcall void MTS_PROTO(lhu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LW: Load Word */
-fastcall void MTS_PROTO(lw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -224,7 +224,7 @@ fastcall void MTS_PROTO(lw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LWU: Load Word Unsigned */
-fastcall void MTS_PROTO(lwu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lwu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -235,7 +235,7 @@ fastcall void MTS_PROTO(lwu)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LD: Load Double-Word */
-fastcall void MTS_PROTO(ld)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(ld)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -246,7 +246,7 @@ fastcall void MTS_PROTO(ld)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SB: Store Byte */
-fastcall void MTS_PROTO(sb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -257,7 +257,7 @@ fastcall void MTS_PROTO(sb)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SH: Store Half-Word */
-fastcall void MTS_PROTO(sh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -268,7 +268,7 @@ fastcall void MTS_PROTO(sh)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SW: Store Word */
-fastcall void MTS_PROTO(sw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -279,7 +279,7 @@ fastcall void MTS_PROTO(sw)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SD: Store Double-Word */
-fastcall void MTS_PROTO(sd)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sd)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -290,7 +290,7 @@ fastcall void MTS_PROTO(sd)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LDC1: Load Double-Word To Coprocessor 1 */
-fastcall void MTS_PROTO(ldc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(ldc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -301,7 +301,7 @@ fastcall void MTS_PROTO(ldc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LWL: Load Word Left */
-fastcall void MTS_PROTO(lwl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lwl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
    m_uint64_t data;
@@ -324,7 +324,7 @@ fastcall void MTS_PROTO(lwl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LWR: Load Word Right */
-fastcall void MTS_PROTO(lwr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(lwr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
    m_uint64_t data;
@@ -348,7 +348,7 @@ fastcall void MTS_PROTO(lwr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LDL: Load Double-Word Left */
-fastcall void MTS_PROTO(ldl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(ldl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
    m_uint64_t data;
@@ -370,7 +370,7 @@ fastcall void MTS_PROTO(ldl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LDR: Load Double-Word Right */
-fastcall void MTS_PROTO(ldr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(ldr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t r_mask,naddr;
    m_uint64_t data;
@@ -392,7 +392,7 @@ fastcall void MTS_PROTO(ldr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SWL: Store Word Left */
-fastcall void MTS_PROTO(swl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(swl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
    m_uint64_t data;
@@ -416,7 +416,7 @@ fastcall void MTS_PROTO(swl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SWR: Store Word Right */
-fastcall void MTS_PROTO(swr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(swr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
    m_uint64_t data;
@@ -440,7 +440,7 @@ fastcall void MTS_PROTO(swr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SDL: Store Double-Word Left */
-fastcall void MTS_PROTO(sdl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sdl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
    m_uint64_t data;
@@ -464,7 +464,7 @@ fastcall void MTS_PROTO(sdl)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SDR: Store Double-Word Right */
-fastcall void MTS_PROTO(sdr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sdr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t d_mask,naddr;
    m_uint64_t data;
@@ -488,7 +488,7 @@ fastcall void MTS_PROTO(sdr)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* LL: Load Linked */
-fastcall void MTS_PROTO(ll)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(ll)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -501,7 +501,7 @@ fastcall void MTS_PROTO(ll)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SC: Store Conditional */
-fastcall void MTS_PROTO(sc)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sc)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -516,7 +516,7 @@ fastcall void MTS_PROTO(sc)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* SDC1: Store Double-Word from Coprocessor 1 */
-fastcall void MTS_PROTO(sdc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
+void MTS_PROTO(sdc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -527,7 +527,7 @@ fastcall void MTS_PROTO(sdc1)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int reg)
 }
 
 /* CACHE: Cache operation */
-fastcall void MTS_PROTO(cache)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int op)
+void MTS_PROTO(cache)(cpu_mips_t *cpu,m_uint64_t vaddr,u_int op)
 {
 #if DEBUG_CACHE
    cpu_log(cpu->gen,

--- a/unstable/ppc32.c
+++ b/unstable/ppc32.c
@@ -320,7 +320,7 @@ void ppc32_trigger_exception(cpu_ppc_t *cpu,u_int exc_vector)
 }
 
 /* Trigger IRQs */
-fastcall void ppc32_trigger_irq(cpu_ppc_t *cpu)
+void ppc32_trigger_irq(cpu_ppc_t *cpu)
 {
    if (unlikely(cpu->irq_disable)) {
       cpu->irq_pending = FALSE;

--- a/unstable/ppc32.c
+++ b/unstable/ppc32.c
@@ -348,7 +348,7 @@ void ppc32_trigger_timer_irq(cpu_ppc_t *cpu)
 }
 
 /* Virtual breakpoint */
-fastcall void ppc32_run_breakpoint(cpu_ppc_t *cpu)
+void ppc32_run_breakpoint(cpu_ppc_t *cpu)
 {
    cpu_log(cpu->gen,"BREAKPOINT",
            "Virtual breakpoint reached at IA=0x%8.8x\n",cpu->ia);

--- a/unstable/ppc32.h
+++ b/unstable/ppc32.h
@@ -512,7 +512,7 @@ void ppc32_trigger_timer_irq(cpu_ppc_t *cpu);
 fastcall void ppc32_trigger_irq(cpu_ppc_t *cpu);
 
 /* Virtual breakpoint */
-fastcall void ppc32_run_breakpoint(cpu_ppc_t *cpu);
+void ppc32_run_breakpoint(cpu_ppc_t *cpu);
 
 /* Add a virtual breakpoint */
 int ppc32_add_breakpoint(cpu_gen_t *cpu,m_uint64_t ia);

--- a/unstable/ppc32.h
+++ b/unstable/ppc32.h
@@ -509,7 +509,7 @@ void ppc32_trigger_exception(cpu_ppc_t *cpu,u_int exc_vector);
 void ppc32_trigger_timer_irq(cpu_ppc_t *cpu);
 
 /* Trigger IRQs */
-fastcall void ppc32_trigger_irq(cpu_ppc_t *cpu);
+void ppc32_trigger_irq(cpu_ppc_t *cpu);
 
 /* Virtual breakpoint */
 void ppc32_run_breakpoint(cpu_ppc_t *cpu);

--- a/unstable/ppc32.h
+++ b/unstable/ppc32.h
@@ -248,7 +248,7 @@ enum {
 typedef struct cpu_ppc cpu_ppc_t;
 
 /* Memory operation function prototype */
-typedef fastcall void (*ppc_memop_fn)(cpu_ppc_t *cpu,m_uint32_t vaddr,
+typedef void (*ppc_memop_fn)(cpu_ppc_t *cpu,m_uint32_t vaddr,
                                       u_int reg);
 
 /* BAT type indexes */

--- a/unstable/ppc32.h
+++ b/unstable/ppc32.h
@@ -308,7 +308,7 @@ struct cpu_ppc {
    ppc32_jit_tcb_t **tcb_virt_hash,**tcb_phys_hash;
 
    /* Virtual address to physical page translation */
-   fastcall int (*translate)(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int cid,
+   int (*translate)(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int cid,
                              m_uint32_t *phys_page);
 
    /* Memory access functions */

--- a/unstable/ppc32_exec.c
+++ b/unstable/ppc32_exec.c
@@ -150,7 +150,7 @@ ppc32_exec_single_instruction(cpu_ppc_t *cpu,ppc_insn_t instruction)
 }
 
 /* Execute a single instruction (external) */
-fastcall int ppc32_exec_single_insn_ext(cpu_ppc_t *cpu,ppc_insn_t insn)
+int ppc32_exec_single_insn_ext(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int res;
 

--- a/unstable/ppc32_exec.c
+++ b/unstable/ppc32_exec.c
@@ -118,7 +118,7 @@ static forced_inline int ppc32_exec_fetch(cpu_ppc_t *cpu,m_uint32_t ia,
 }
 
 /* Unknown opcode */
-static fastcall int ppc32_exec_unknown(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_unknown(cpu_ppc_t *cpu,ppc_insn_t insn)
 {   
    printf("PPC32: unknown opcode 0x%8.8x at ia = 0x%x\n",insn,cpu->ia);
    ppc32_dump_regs(cpu->gen);
@@ -129,7 +129,7 @@ static fastcall int ppc32_exec_unknown(cpu_ppc_t *cpu,ppc_insn_t insn)
 static forced_inline int 
 ppc32_exec_single_instruction(cpu_ppc_t *cpu,ppc_insn_t instruction)
 {
-   register fastcall int (*exec)(cpu_ppc_t *,ppc_insn_t) = NULL;
+   register int (*exec)(cpu_ppc_t *,ppc_insn_t) = NULL;
    struct ppc32_insn_exec_tag *tag;
    int index;
    
@@ -363,7 +363,7 @@ static forced_inline int ppc32_check_cond(cpu_ppc_t *cpu,m_uint32_t bo,
 }
 
 /* MFLR - Move From Link Register */
-static fastcall int ppc32_exec_MFLR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFLR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
 
@@ -372,7 +372,7 @@ static fastcall int ppc32_exec_MFLR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MTLR - Move To Link Register */
-static fastcall int ppc32_exec_MTLR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTLR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
 
@@ -381,7 +381,7 @@ static fastcall int ppc32_exec_MTLR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFCTR - Move From Counter Register */
-static fastcall int ppc32_exec_MFCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
 
@@ -390,7 +390,7 @@ static fastcall int ppc32_exec_MFCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MTCTR - Move To Counter Register */
-static fastcall int ppc32_exec_MTCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
 
@@ -399,7 +399,7 @@ static fastcall int ppc32_exec_MTCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADD */
-static fastcall int ppc32_exec_ADD(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADD(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -410,7 +410,7 @@ static fastcall int ppc32_exec_ADD(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADD. */
-static fastcall int ppc32_exec_ADD_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADD_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -424,7 +424,7 @@ static fastcall int ppc32_exec_ADD_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDO - Add with Overflow */
-static fastcall int ppc32_exec_ADDO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -441,7 +441,7 @@ static fastcall int ppc32_exec_ADDO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDO. */
-static fastcall int ppc32_exec_ADDO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -459,7 +459,7 @@ static fastcall int ppc32_exec_ADDO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDC - Add Carrying */
-static fastcall int ppc32_exec_ADDC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -476,7 +476,7 @@ static fastcall int ppc32_exec_ADDC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDC. */
-static fastcall int ppc32_exec_ADDC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -494,7 +494,7 @@ static fastcall int ppc32_exec_ADDC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDCO - Add Carrying with Overflow */
-static fastcall int ppc32_exec_ADDCO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDCO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -512,7 +512,7 @@ static fastcall int ppc32_exec_ADDCO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDCO. */
-static fastcall int ppc32_exec_ADDCO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDCO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -531,7 +531,7 @@ static fastcall int ppc32_exec_ADDCO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDE - Add Extended */
-static fastcall int ppc32_exec_ADDE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -554,7 +554,7 @@ static fastcall int ppc32_exec_ADDE(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDE. */
-static fastcall int ppc32_exec_ADDE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -578,7 +578,7 @@ static fastcall int ppc32_exec_ADDE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDEO - Add Extended with Overflow */
-static fastcall int ppc32_exec_ADDEO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDEO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -602,7 +602,7 @@ static fastcall int ppc32_exec_ADDEO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDEO. */
-static fastcall int ppc32_exec_ADDEO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDEO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -627,7 +627,7 @@ static fastcall int ppc32_exec_ADDEO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDI - ADD Immediate */
-static fastcall int ppc32_exec_ADDI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -644,7 +644,7 @@ static fastcall int ppc32_exec_ADDI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDIC - ADD Immediate with Carry */
-static fastcall int ppc32_exec_ADDIC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDIC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -659,7 +659,7 @@ static fastcall int ppc32_exec_ADDIC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDIC. */
-static fastcall int ppc32_exec_ADDIC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDIC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -675,7 +675,7 @@ static fastcall int ppc32_exec_ADDIC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDIS - ADD Immediate Shifted */
-static fastcall int ppc32_exec_ADDIS(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDIS(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -692,7 +692,7 @@ static fastcall int ppc32_exec_ADDIS(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDME - Add to Minus One Extended */
-static fastcall int ppc32_exec_ADDME(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDME(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -714,7 +714,7 @@ static fastcall int ppc32_exec_ADDME(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDME. */
-static fastcall int ppc32_exec_ADDME_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDME_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -737,7 +737,7 @@ static fastcall int ppc32_exec_ADDME_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDZE - Add to Zero Extended */
-static fastcall int ppc32_exec_ADDZE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDZE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -758,7 +758,7 @@ static fastcall int ppc32_exec_ADDZE(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ADDZE. */
-static fastcall int ppc32_exec_ADDZE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ADDZE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -780,7 +780,7 @@ static fastcall int ppc32_exec_ADDZE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* AND */
-static fastcall int ppc32_exec_AND(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_AND(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -791,7 +791,7 @@ static fastcall int ppc32_exec_AND(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* AND. */
-static fastcall int ppc32_exec_AND_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_AND_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -805,7 +805,7 @@ static fastcall int ppc32_exec_AND_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ANDC - AND with Complement */
-static fastcall int ppc32_exec_ANDC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ANDC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -816,7 +816,7 @@ static fastcall int ppc32_exec_ANDC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ANDC. - AND with Complement */
-static fastcall int ppc32_exec_ANDC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ANDC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -830,7 +830,7 @@ static fastcall int ppc32_exec_ANDC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ANDI. - AND Immediate */
-static fastcall int ppc32_exec_ANDI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ANDI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -844,7 +844,7 @@ static fastcall int ppc32_exec_ANDI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ANDIS. - AND Immediate Shifted */
-static fastcall int ppc32_exec_ANDIS_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ANDIS_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs  = bits(insn,21,25);
    int ra  = bits(insn,16,20);
@@ -858,7 +858,7 @@ static fastcall int ppc32_exec_ANDIS_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* B - Branch */
-static fastcall int ppc32_exec_B(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_B(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    m_uint32_t offset = bits(insn,2,25);
 
@@ -867,7 +867,7 @@ static fastcall int ppc32_exec_B(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BA - Branch Absolute */
-static fastcall int ppc32_exec_BA(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BA(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    m_uint32_t offset = bits(insn,2,25);
 
@@ -876,7 +876,7 @@ static fastcall int ppc32_exec_BA(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BL - Branch and Link */
-static fastcall int ppc32_exec_BL(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BL(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    m_uint32_t offset = bits(insn,2,25);
 
@@ -886,7 +886,7 @@ static fastcall int ppc32_exec_BL(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BLA - Branch and Link Absolute */
-static fastcall int ppc32_exec_BLA(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BLA(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    m_uint32_t offset = bits(insn,2,25);
 
@@ -896,7 +896,7 @@ static fastcall int ppc32_exec_BLA(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BC - Branch Conditional */
-static fastcall int ppc32_exec_BC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -911,7 +911,7 @@ static fastcall int ppc32_exec_BC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCA - Branch Conditional (absolute) */
-static fastcall int ppc32_exec_BCA(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCA(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -926,7 +926,7 @@ static fastcall int ppc32_exec_BCA(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCL - Branch Conditional and Link */
-static fastcall int ppc32_exec_BCL(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCL(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -943,7 +943,7 @@ static fastcall int ppc32_exec_BCL(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCLA - Branch Conditional and Link (absolute) */
-static fastcall int ppc32_exec_BCLA(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCLA(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -960,7 +960,7 @@ static fastcall int ppc32_exec_BCLA(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCLR - Branch Conditional to Link register */
-static fastcall int ppc32_exec_BCLR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCLR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -974,7 +974,7 @@ static fastcall int ppc32_exec_BCLR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCLRL - Branch Conditional to Link register */
-static fastcall int ppc32_exec_BCLRL(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCLRL(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -992,7 +992,7 @@ static fastcall int ppc32_exec_BCLRL(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCCTR - Branch Conditional to Count register */
-static fastcall int ppc32_exec_BCCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -1006,7 +1006,7 @@ static fastcall int ppc32_exec_BCCTR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* BCCTRL - Branch Conditional to Count register and Link */
-static fastcall int ppc32_exec_BCCTRL(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_BCCTRL(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bo = bits(insn,21,25);
    int bi = bits(insn,16,20);
@@ -1022,7 +1022,7 @@ static fastcall int ppc32_exec_BCCTRL(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CMP - Compare */
-static fastcall int ppc32_exec_CMP(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CMP(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,23,25);
    int ra = bits(insn,16,20);
@@ -1050,7 +1050,7 @@ static fastcall int ppc32_exec_CMP(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CMPI - Compare Immediate */
-static fastcall int ppc32_exec_CMPI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CMPI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,23,25);
    int ra = bits(insn,16,20);
@@ -1078,7 +1078,7 @@ static fastcall int ppc32_exec_CMPI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CMPL - Compare Logical */
-static fastcall int ppc32_exec_CMPL(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CMPL(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,23,25);
    int ra = bits(insn,16,20);
@@ -1105,7 +1105,7 @@ static fastcall int ppc32_exec_CMPL(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CMPLI - Compare Logical Immediate */
-static fastcall int ppc32_exec_CMPLI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CMPLI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,23,25);
    int ra = bits(insn,16,20);
@@ -1131,7 +1131,7 @@ static fastcall int ppc32_exec_CMPLI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CNTLZW - Count Leading Zeros Word */
-static fastcall int ppc32_exec_CNTLZW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CNTLZW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1153,7 +1153,7 @@ static fastcall int ppc32_exec_CNTLZW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CRAND - Condition Register AND */
-static fastcall int ppc32_exec_CRAND(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CRAND(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1172,7 +1172,7 @@ static fastcall int ppc32_exec_CRAND(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CREQV - Condition Register Equivalent */
-static fastcall int ppc32_exec_CREQV(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CREQV(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1191,7 +1191,7 @@ static fastcall int ppc32_exec_CREQV(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CRANDC - Condition Register AND with Complement */
-static fastcall int ppc32_exec_CRANDC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CRANDC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1210,7 +1210,7 @@ static fastcall int ppc32_exec_CRANDC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CRNAND - Condition Register NAND */
-static fastcall int ppc32_exec_CRNAND(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CRNAND(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1229,7 +1229,7 @@ static fastcall int ppc32_exec_CRNAND(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CRNOR - Condition Register NOR */
-static fastcall int ppc32_exec_CRNOR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CRNOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1248,7 +1248,7 @@ static fastcall int ppc32_exec_CRNOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CROR - Condition Register OR */
-static fastcall int ppc32_exec_CROR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CROR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1267,7 +1267,7 @@ static fastcall int ppc32_exec_CROR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CRORC - Condition Register OR with complement */
-static fastcall int ppc32_exec_CRORC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CRORC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1286,7 +1286,7 @@ static fastcall int ppc32_exec_CRORC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* CRXOR - Condition Register XOR */
-static fastcall int ppc32_exec_CRXOR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_CRXOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int bd = bits(insn,21,25);
    int bb = bits(insn,16,20);
@@ -1305,7 +1305,7 @@ static fastcall int ppc32_exec_CRXOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DCBF - Data Cache Block Flush */
-static fastcall int ppc32_exec_DCBF(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DCBF(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -1321,7 +1321,7 @@ static fastcall int ppc32_exec_DCBF(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DCBI - Data Cache Block Invalidate */
-static fastcall int ppc32_exec_DCBI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DCBI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -1337,7 +1337,7 @@ static fastcall int ppc32_exec_DCBI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DCBT - Data Cache Block Touch */
-static fastcall int ppc32_exec_DCBT(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DCBT(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -1353,7 +1353,7 @@ static fastcall int ppc32_exec_DCBT(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DCBST - Data Cache Block Store */
-static fastcall int ppc32_exec_DCBST(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DCBST(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -1369,7 +1369,7 @@ static fastcall int ppc32_exec_DCBST(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DIVW - Divide Word */
-static fastcall int ppc32_exec_DIVW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DIVW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1385,7 +1385,7 @@ static fastcall int ppc32_exec_DIVW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DIVW. - Divide Word */
-static fastcall int ppc32_exec_DIVW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DIVW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1405,7 +1405,7 @@ static fastcall int ppc32_exec_DIVW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DIVWU - Divide Word Unsigned */
-static fastcall int ppc32_exec_DIVWU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DIVWU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1421,7 +1421,7 @@ static fastcall int ppc32_exec_DIVWU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DIVWU. - Divide Word Unsigned */
-static fastcall int ppc32_exec_DIVWU_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DIVWU_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1441,13 +1441,13 @@ static fastcall int ppc32_exec_DIVWU_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* EIEIO - Enforce In-order Execution of I/O */
-static fastcall int ppc32_exec_EIEIO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_EIEIO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    return(0);
 }
 
 /* EQV */
-static fastcall int ppc32_exec_EQV(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_EQV(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1458,7 +1458,7 @@ static fastcall int ppc32_exec_EQV(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* EXTSB - Extend Sign Byte */
-static fastcall int ppc32_exec_EXTSB(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_EXTSB(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1468,7 +1468,7 @@ static fastcall int ppc32_exec_EXTSB(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* EXTSB. */
-static fastcall int ppc32_exec_EXTSB_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_EXTSB_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1481,7 +1481,7 @@ static fastcall int ppc32_exec_EXTSB_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* EXTSH - Extend Sign Word */
-static fastcall int ppc32_exec_EXTSH(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_EXTSH(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1491,7 +1491,7 @@ static fastcall int ppc32_exec_EXTSH(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* EXTSH. */
-static fastcall int ppc32_exec_EXTSH_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_EXTSH_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1504,7 +1504,7 @@ static fastcall int ppc32_exec_EXTSH_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ICBI - Instruction Cache Block Invalidate */
-static fastcall int ppc32_exec_ICBI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ICBI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -1520,13 +1520,13 @@ static fastcall int ppc32_exec_ICBI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ISYNC - Instruction Synchronize */
-static fastcall int ppc32_exec_ISYNC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ISYNC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    return(0);
 }
 
 /* LBZ - Load Byte and Zero */
-static fastcall int ppc32_exec_LBZ(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LBZ(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1543,7 +1543,7 @@ static fastcall int ppc32_exec_LBZ(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LBZU - Load Byte and Zero with Update */
-static fastcall int ppc32_exec_LBZU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LBZU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1557,7 +1557,7 @@ static fastcall int ppc32_exec_LBZU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LBZUX - Load Byte and Zero with Update Indexed */
-static fastcall int ppc32_exec_LBZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LBZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1571,7 +1571,7 @@ static fastcall int ppc32_exec_LBZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LBZX - Load Byte and Zero Indexed */
-static fastcall int ppc32_exec_LBZX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LBZX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1588,7 +1588,7 @@ static fastcall int ppc32_exec_LBZX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHA - Load Half-Word Algebraic */
-static fastcall int ppc32_exec_LHA(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHA(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1605,7 +1605,7 @@ static fastcall int ppc32_exec_LHA(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHAU - Load Half-Word Algebraic with Update */
-static fastcall int ppc32_exec_LHAU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHAU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1619,7 +1619,7 @@ static fastcall int ppc32_exec_LHAU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHAUX - Load Half-Word Algebraic with Update Indexed */
-static fastcall int ppc32_exec_LHAUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHAUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1633,7 +1633,7 @@ static fastcall int ppc32_exec_LHAUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHAX - Load Half-Word Algebraic ndexed */
-static fastcall int ppc32_exec_LHAX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHAX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1650,7 +1650,7 @@ static fastcall int ppc32_exec_LHAX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHZ - Load Half-Word and Zero */
-static fastcall int ppc32_exec_LHZ(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHZ(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1667,7 +1667,7 @@ static fastcall int ppc32_exec_LHZ(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHZU - Load Half-Word and Zero with Update */
-static fastcall int ppc32_exec_LHZU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHZU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1681,7 +1681,7 @@ static fastcall int ppc32_exec_LHZU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHZUX - Load Half-Word and Zero with Update Indexed */
-static fastcall int ppc32_exec_LHZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1695,7 +1695,7 @@ static fastcall int ppc32_exec_LHZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LHZX - Load Half-Word and Zero Indexed */
-static fastcall int ppc32_exec_LHZX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LHZX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1712,7 +1712,7 @@ static fastcall int ppc32_exec_LHZX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LMW - Load Multiple Word */
-static fastcall int ppc32_exec_LMW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LMW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1734,7 +1734,7 @@ static fastcall int ppc32_exec_LMW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LWBRX - Load Word Byte-Reverse Indexed */
-static fastcall int ppc32_exec_LWBRX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LWBRX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1751,7 +1751,7 @@ static fastcall int ppc32_exec_LWBRX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LWZ - Load Word and Zero */
-static fastcall int ppc32_exec_LWZ(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LWZ(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1768,7 +1768,7 @@ static fastcall int ppc32_exec_LWZ(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LWZU - Load Word and Zero with Update */
-static fastcall int ppc32_exec_LWZU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LWZU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1782,7 +1782,7 @@ static fastcall int ppc32_exec_LWZU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LWZUX - Load Word and Zero with Update Indexed */
-static fastcall int ppc32_exec_LWZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LWZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1796,7 +1796,7 @@ static fastcall int ppc32_exec_LWZUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LWZX - Load Word and Zero Indexed */
-static fastcall int ppc32_exec_LWZX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LWZX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1813,7 +1813,7 @@ static fastcall int ppc32_exec_LWZX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LWARX - Load Word and Reserve Indexed */
-static fastcall int ppc32_exec_LWARX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LWARX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1831,7 +1831,7 @@ static fastcall int ppc32_exec_LWARX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LFD - Load Floating-Point Double */
-static fastcall int ppc32_exec_LFD(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LFD(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1848,7 +1848,7 @@ static fastcall int ppc32_exec_LFD(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LFDU - Load Floating-Point Double with Update */
-static fastcall int ppc32_exec_LFDU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LFDU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1862,7 +1862,7 @@ static fastcall int ppc32_exec_LFDU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LFDUX - Load Floating-Point Double with Update Indexed */
-static fastcall int ppc32_exec_LFDUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LFDUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1876,7 +1876,7 @@ static fastcall int ppc32_exec_LFDUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LFDX - Load Floating-Point Double Indexed */
-static fastcall int ppc32_exec_LFDX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LFDX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1893,7 +1893,7 @@ static fastcall int ppc32_exec_LFDX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LSWI - Load String Word Immediate */
-static fastcall int ppc32_exec_LSWI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LSWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1930,7 +1930,7 @@ static fastcall int ppc32_exec_LSWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* LSWX - Load String Word Indexed */
-static fastcall int ppc32_exec_LSWX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_LSWX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -1967,7 +1967,7 @@ static fastcall int ppc32_exec_LSWX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MCRF - Move Condition Register Field */
-static fastcall int ppc32_exec_MCRF(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MCRF(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,23,25);
    int rs = bits(insn,18,20);
@@ -1977,7 +1977,7 @@ static fastcall int ppc32_exec_MCRF(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFCR - Move from Condition Register */
-static fastcall int ppc32_exec_MFCR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFCR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
 
@@ -1986,7 +1986,7 @@ static fastcall int ppc32_exec_MFCR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFMSR - Move from Machine State Register */
-static fastcall int ppc32_exec_MFMSR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFMSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
 
@@ -1995,7 +1995,7 @@ static fastcall int ppc32_exec_MFMSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFTBU - Move from Time Base (Up) */
-static fastcall int ppc32_exec_MFTBU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFTBU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
 
@@ -2004,7 +2004,7 @@ static fastcall int ppc32_exec_MFTBU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFTBL - Move from Time Base (Lo) */
-static fastcall int ppc32_exec_MFTBL(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFTBL(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
 
@@ -2015,7 +2015,7 @@ static fastcall int ppc32_exec_MFTBL(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFSPR - Move from Special-Purpose Register */
-static fastcall int ppc32_exec_MFSPR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFSPR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd   = bits(insn,21,25);
    int spr0 = bits(insn,16,20);
@@ -2099,7 +2099,7 @@ static fastcall int ppc32_exec_MFSPR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFSR - Move From Segment Register */
-static fastcall int ppc32_exec_MFSR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {   
    int rd = bits(insn,21,25);
    int sr = bits(insn,16,19);
@@ -2109,7 +2109,7 @@ static fastcall int ppc32_exec_MFSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFSRIN - Move From Segment Register Indirect */
-static fastcall int ppc32_exec_MFSRIN(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFSRIN(cpu_ppc_t *cpu,ppc_insn_t insn)
 {   
    int rd = bits(insn,21,25);
    int rb = bits(insn,11,15);
@@ -2119,7 +2119,7 @@ static fastcall int ppc32_exec_MFSRIN(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MTCRF - Move to Condition Register Fields */
-static fastcall int ppc32_exec_MTCRF(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTCRF(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int crm = bits(insn,12,19);
@@ -2133,7 +2133,7 @@ static fastcall int ppc32_exec_MTCRF(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MTMSR - Move to Machine State Register */
-static fastcall int ppc32_exec_MTMSR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTMSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
 
@@ -2145,7 +2145,7 @@ static fastcall int ppc32_exec_MTMSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MTSPR - Move to Special-Purpose Register */
-static fastcall int ppc32_exec_MTSPR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTSPR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd   = bits(insn,21,25);
    int spr0 = bits(insn,16,20);
@@ -2212,7 +2212,7 @@ static fastcall int ppc32_exec_MTSPR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MTSR - Move To Segment Register */
-static fastcall int ppc32_exec_MTSR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {   
    int rs = bits(insn,21,25);
    int sr = bits(insn,16,19);
@@ -2223,7 +2223,7 @@ static fastcall int ppc32_exec_MTSR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULHW - Multiply High Word */
-static fastcall int ppc32_exec_MULHW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULHW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2240,7 +2240,7 @@ static fastcall int ppc32_exec_MULHW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULHW. */
-static fastcall int ppc32_exec_MULHW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULHW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2257,7 +2257,7 @@ static fastcall int ppc32_exec_MULHW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULHWU - Multiply High Word Unsigned */
-static fastcall int ppc32_exec_MULHWU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULHWU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2274,7 +2274,7 @@ static fastcall int ppc32_exec_MULHWU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULHWU. */
-static fastcall int ppc32_exec_MULHWU_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULHWU_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2291,7 +2291,7 @@ static fastcall int ppc32_exec_MULHWU_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULLI - Multiply Low Immediate */
-static fastcall int ppc32_exec_MULLI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULLI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2302,7 +2302,7 @@ static fastcall int ppc32_exec_MULLI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULLW - Multiply Low Word */
-static fastcall int ppc32_exec_MULLW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULLW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2316,7 +2316,7 @@ static fastcall int ppc32_exec_MULLW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULLW. */
-static fastcall int ppc32_exec_MULLW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULLW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2334,7 +2334,7 @@ static fastcall int ppc32_exec_MULLW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULLWO - Multiply Low Word with Overflow */
-static fastcall int ppc32_exec_MULLWO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULLWO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2354,7 +2354,7 @@ static fastcall int ppc32_exec_MULLWO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MULLWO. */
-static fastcall int ppc32_exec_MULLWO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MULLWO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2377,7 +2377,7 @@ static fastcall int ppc32_exec_MULLWO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NAND */
-static fastcall int ppc32_exec_NAND(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NAND(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2388,7 +2388,7 @@ static fastcall int ppc32_exec_NAND(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NAND. */
-static fastcall int ppc32_exec_NAND_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NAND_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2402,7 +2402,7 @@ static fastcall int ppc32_exec_NAND_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NEG - Negate */
-static fastcall int ppc32_exec_NEG(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NEG(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2412,7 +2412,7 @@ static fastcall int ppc32_exec_NEG(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NEG. */
-static fastcall int ppc32_exec_NEG_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NEG_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2425,7 +2425,7 @@ static fastcall int ppc32_exec_NEG_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NEGO */
-static fastcall int ppc32_exec_NEGO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NEGO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2444,7 +2444,7 @@ static fastcall int ppc32_exec_NEGO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NEGO. */
-static fastcall int ppc32_exec_NEGO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NEGO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2463,7 +2463,7 @@ static fastcall int ppc32_exec_NEGO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NOR */
-static fastcall int ppc32_exec_NOR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2474,7 +2474,7 @@ static fastcall int ppc32_exec_NOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* NOR. */
-static fastcall int ppc32_exec_NOR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_NOR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2488,7 +2488,7 @@ static fastcall int ppc32_exec_NOR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* OR */
-static fastcall int ppc32_exec_OR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_OR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2499,7 +2499,7 @@ static fastcall int ppc32_exec_OR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* OR. */
-static fastcall int ppc32_exec_OR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_OR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2513,7 +2513,7 @@ static fastcall int ppc32_exec_OR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ORC - OR with Complement */
-static fastcall int ppc32_exec_ORC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ORC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2524,7 +2524,7 @@ static fastcall int ppc32_exec_ORC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ORC. */
-static fastcall int ppc32_exec_ORC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ORC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2538,7 +2538,7 @@ static fastcall int ppc32_exec_ORC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ORI - OR Immediate */
-static fastcall int ppc32_exec_ORI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ORI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2549,7 +2549,7 @@ static fastcall int ppc32_exec_ORI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ORIS - OR Immediate Shifted */
-static fastcall int ppc32_exec_ORIS(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ORIS(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2560,7 +2560,7 @@ static fastcall int ppc32_exec_ORIS(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RFI - Return From Interrupt */
-static fastcall int ppc32_exec_RFI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RFI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    //printf("RFI: srr0=0x%8.8x, srr1=0x%8.8x\n",cpu->srr0,cpu->srr1);
 
@@ -2577,7 +2577,7 @@ static fastcall int ppc32_exec_RFI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RLWIMI - Rotate Left Word Immediate then Mask Insert */
-static fastcall int ppc32_exec_RLWIMI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RLWIMI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2593,7 +2593,7 @@ static fastcall int ppc32_exec_RLWIMI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RLWIMI. - Rotate Left Word Immediate then Mask Insert */
-static fastcall int ppc32_exec_RLWIMI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RLWIMI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2611,7 +2611,7 @@ static fastcall int ppc32_exec_RLWIMI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RLWINM - Rotate Left Word Immediate AND with Mask */
-static fastcall int ppc32_exec_RLWINM(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RLWINM(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2627,7 +2627,7 @@ static fastcall int ppc32_exec_RLWINM(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RLWINM. - Rotate Left Word Immediate AND with Mask */
-static fastcall int ppc32_exec_RLWINM_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RLWINM_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2645,7 +2645,7 @@ static fastcall int ppc32_exec_RLWINM_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RLWNM - Rotate Left Word then Mask Insert */
-static fastcall int ppc32_exec_RLWNM(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RLWNM(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2662,7 +2662,7 @@ static fastcall int ppc32_exec_RLWNM(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* RLWNM. - Rotate Left Word then Mask Insert */
-static fastcall int ppc32_exec_RLWNM_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_RLWNM_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2681,14 +2681,14 @@ static fastcall int ppc32_exec_RLWNM_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SC - System Call */
-static fastcall int ppc32_exec_SC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    ppc32_trigger_exception(cpu,PPC32_EXC_SYSCALL);
    return(1);
 }
 
 /* SLW - Shift Left Word */
-static fastcall int ppc32_exec_SLW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SLW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2706,7 +2706,7 @@ static fastcall int ppc32_exec_SLW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SLW. */
-static fastcall int ppc32_exec_SLW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SLW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2726,7 +2726,7 @@ static fastcall int ppc32_exec_SLW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SRAW - Shift Right Algebraic Word */
-static fastcall int ppc32_exec_SRAW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SRAW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2755,7 +2755,7 @@ static fastcall int ppc32_exec_SRAW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SRAWI - Shift Right Algebraic Word Immediate */
-static fastcall int ppc32_exec_SRAWI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SRAWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2775,7 +2775,7 @@ static fastcall int ppc32_exec_SRAWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SRAWI. */
-static fastcall int ppc32_exec_SRAWI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SRAWI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2797,7 +2797,7 @@ static fastcall int ppc32_exec_SRAWI_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SRW - Shift Right Word */
-static fastcall int ppc32_exec_SRW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SRW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2815,7 +2815,7 @@ static fastcall int ppc32_exec_SRW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SRW. */
-static fastcall int ppc32_exec_SRW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SRW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2835,7 +2835,7 @@ static fastcall int ppc32_exec_SRW_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STB - Store Byte */
-static fastcall int ppc32_exec_STB(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STB(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2852,7 +2852,7 @@ static fastcall int ppc32_exec_STB(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STBU - Store Byte with Update */
-static fastcall int ppc32_exec_STBU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STBU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2866,7 +2866,7 @@ static fastcall int ppc32_exec_STBU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STBUX - Store Byte with Update Indexed */
-static fastcall int ppc32_exec_STBUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STBUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2880,7 +2880,7 @@ static fastcall int ppc32_exec_STBUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STBX - Store Byte Indexed */
-static fastcall int ppc32_exec_STBX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STBX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2897,7 +2897,7 @@ static fastcall int ppc32_exec_STBX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STH - Store Half-Word */
-static fastcall int ppc32_exec_STH(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STH(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2914,7 +2914,7 @@ static fastcall int ppc32_exec_STH(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STHU - Store Half-Word with Update */
-static fastcall int ppc32_exec_STHU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STHU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs  = bits(insn,21,25);
    int ra  = bits(insn,16,20);
@@ -2928,7 +2928,7 @@ static fastcall int ppc32_exec_STHU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STHUX - Store Half-Word with Update Indexed */
-static fastcall int ppc32_exec_STHUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STHUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2942,7 +2942,7 @@ static fastcall int ppc32_exec_STHUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STHX - Store Half-Word Indexed */
-static fastcall int ppc32_exec_STHX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STHX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2959,7 +2959,7 @@ static fastcall int ppc32_exec_STHX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STMW - Store Multiple Word */
-static fastcall int ppc32_exec_STMW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STMW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2981,7 +2981,7 @@ static fastcall int ppc32_exec_STMW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STW - Store Word */
-static fastcall int ppc32_exec_STW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -2998,7 +2998,7 @@ static fastcall int ppc32_exec_STW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STWU - Store Word with Update */
-static fastcall int ppc32_exec_STWU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STWU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3012,7 +3012,7 @@ static fastcall int ppc32_exec_STWU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STWUX - Store Word with Update Indexed */
-static fastcall int ppc32_exec_STWUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STWUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3026,7 +3026,7 @@ static fastcall int ppc32_exec_STWUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STWX - Store Word Indexed */
-static fastcall int ppc32_exec_STWX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STWX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3043,7 +3043,7 @@ static fastcall int ppc32_exec_STWX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STWBRX - Store Word Byte-Reverse Indexed */
-static fastcall int ppc32_exec_STWBRX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STWBRX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3060,7 +3060,7 @@ static fastcall int ppc32_exec_STWBRX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STWCX. - Store Word Conditional Indexed */
-static fastcall int ppc32_exec_STWCX_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STWCX_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3092,7 +3092,7 @@ static fastcall int ppc32_exec_STWCX_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STFD - Store Floating-Point Double */
-static fastcall int ppc32_exec_STFD(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STFD(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3109,7 +3109,7 @@ static fastcall int ppc32_exec_STFD(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STFDU - Store Floating-Point Double with Update */
-static fastcall int ppc32_exec_STFDU(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STFDU(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3123,7 +3123,7 @@ static fastcall int ppc32_exec_STFDU(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STFDUX - Store Floating-Point Double with Update Indexed */
-static fastcall int ppc32_exec_STFDUX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STFDUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3137,7 +3137,7 @@ static fastcall int ppc32_exec_STFDUX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STFDX - Store Floating-Point Double Indexed */
-static fastcall int ppc32_exec_STFDX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STFDX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3154,7 +3154,7 @@ static fastcall int ppc32_exec_STFDX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STSWI - Store String Word Immediate */
-static fastcall int ppc32_exec_STSWI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STSWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3189,7 +3189,7 @@ static fastcall int ppc32_exec_STSWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* STSWX - Store String Word Indexed */
-static fastcall int ppc32_exec_STSWX(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_STSWX(cpu_ppc_t *cpu,ppc_insn_t insn)
 {  
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3224,7 +3224,7 @@ static fastcall int ppc32_exec_STSWX(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBF - Subtract From */
-static fastcall int ppc32_exec_SUBF(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBF(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3235,7 +3235,7 @@ static fastcall int ppc32_exec_SUBF(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBF. */
-static fastcall int ppc32_exec_SUBF_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBF_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3249,7 +3249,7 @@ static fastcall int ppc32_exec_SUBF_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFO - Subtract From with Overflow */
-static fastcall int ppc32_exec_SUBFO(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3266,7 +3266,7 @@ static fastcall int ppc32_exec_SUBFO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFO. */
-static fastcall int ppc32_exec_SUBFO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3284,7 +3284,7 @@ static fastcall int ppc32_exec_SUBFO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFC - Subtract From Carrying */
-static fastcall int ppc32_exec_SUBFC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3306,7 +3306,7 @@ static fastcall int ppc32_exec_SUBFC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFC. */
-static fastcall int ppc32_exec_SUBFC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3329,7 +3329,7 @@ static fastcall int ppc32_exec_SUBFC_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFCO - Subtract From with Overflow */
-_Unused static fastcall int ppc32_exec_SUBFCO(cpu_ppc_t *cpu,ppc_insn_t insn)
+_Unused static int ppc32_exec_SUBFCO(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3347,7 +3347,7 @@ _Unused static fastcall int ppc32_exec_SUBFCO(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFCO. */
-_Unused static fastcall int ppc32_exec_SUBFCO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+_Unused static int ppc32_exec_SUBFCO_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3366,7 +3366,7 @@ _Unused static fastcall int ppc32_exec_SUBFCO_dot(cpu_ppc_t *cpu,ppc_insn_t insn
 }
 
 /* SUBFE - Subtract From Carrying */
-static fastcall int ppc32_exec_SUBFE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3390,7 +3390,7 @@ static fastcall int ppc32_exec_SUBFE(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFIC - Subtract From Immediate Carrying */
-static fastcall int ppc32_exec_SUBFIC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFIC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3412,7 +3412,7 @@ static fastcall int ppc32_exec_SUBFIC(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFZE - Subtract From Zero extended */
-static fastcall int ppc32_exec_SUBFZE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFZE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3432,7 +3432,7 @@ static fastcall int ppc32_exec_SUBFZE(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SUBFZE. */
-static fastcall int ppc32_exec_SUBFZE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SUBFZE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rd = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3453,33 +3453,33 @@ static fastcall int ppc32_exec_SUBFZE_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* SYNC - Synchronize */
-static fastcall int ppc32_exec_SYNC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_SYNC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    return(0);
 }
 
 /* TLBIA - TLB Invalidate All */
-static fastcall int ppc32_exec_TLBIA(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TLBIA(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    ppc32_mem_invalidate_cache(cpu);
    return(0);
 }
 
 /* TLBIE - TLB Invalidate Entry */
-static fastcall int ppc32_exec_TLBIE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TLBIE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    ppc32_mem_invalidate_cache(cpu);
    return(0);
 }
 
 /* TLBSYNC - TLB Synchronize */
-static fastcall int ppc32_exec_TLBSYNC(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TLBSYNC(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    return(0);
 }
 
 /* TW - Trap Word */
-static fastcall int ppc32_exec_TW(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TW(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int to = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3504,7 +3504,7 @@ static fastcall int ppc32_exec_TW(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* TWI - Trap Word Immediate */
-static fastcall int ppc32_exec_TWI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int to = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3529,7 +3529,7 @@ static fastcall int ppc32_exec_TWI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* XOR */
-static fastcall int ppc32_exec_XOR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_XOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3540,7 +3540,7 @@ static fastcall int ppc32_exec_XOR(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* XOR. */
-static fastcall int ppc32_exec_XOR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_XOR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3554,7 +3554,7 @@ static fastcall int ppc32_exec_XOR_dot(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* XORI - XOR Immediate */
-static fastcall int ppc32_exec_XORI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_XORI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3565,7 +3565,7 @@ static fastcall int ppc32_exec_XORI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* XORIS - XOR Immediate Shifted */
-static fastcall int ppc32_exec_XORIS(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_XORIS(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3576,7 +3576,7 @@ static fastcall int ppc32_exec_XORIS(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* DCCCI - Data Cache Congruence Class Invalidate (PowerPC 405) */
-static fastcall int ppc32_exec_DCCCI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_DCCCI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -3591,7 +3591,7 @@ static fastcall int ppc32_exec_DCCCI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* ICCCI - Instruction Cache Congruence Class Invalidate (PowerPC 405) */
-static fastcall int ppc32_exec_ICCCI(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_ICCCI(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int ra = bits(insn,16,20);
    int rb = bits(insn,11,15);
@@ -3606,21 +3606,21 @@ static fastcall int ppc32_exec_ICCCI(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* MFDCR - Move From Device Control Register (PowerPC 405) */
-static fastcall int ppc32_exec_MFDCR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MFDCR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int UNUSED(rt) = bits(insn,21,25);
    return(0);
 }
 
 /* MTDCR - Move To Device Control Register (PowerPC 405) */
-static fastcall int ppc32_exec_MTDCR(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_MTDCR(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int UNUSED(rt) = bits(insn,21,25);
    return(0);
 }
 
 /* TLBRE - TLB Read Entry (PowerPC 405) */
-static fastcall int ppc32_exec_TLBRE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TLBRE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rt = bits(insn,21,25);
    int ra = bits(insn,16,20);
@@ -3640,7 +3640,7 @@ static fastcall int ppc32_exec_TLBRE(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* TLBWE - TLB Write Entry (PowerPC 405) */
-static fastcall int ppc32_exec_TLBWE(cpu_ppc_t *cpu,ppc_insn_t insn)
+static int ppc32_exec_TLBWE(cpu_ppc_t *cpu,ppc_insn_t insn)
 {
    int rs = bits(insn,21,25);
    int ra = bits(insn,16,20);

--- a/unstable/ppc32_exec.c
+++ b/unstable/ppc32_exec.c
@@ -160,7 +160,7 @@ int ppc32_exec_single_insn_ext(cpu_ppc_t *cpu,ppc_insn_t insn)
 }
 
 /* Execute a page */
-fastcall int ppc32_exec_page(cpu_ppc_t *cpu)
+int ppc32_exec_page(cpu_ppc_t *cpu)
 {
    m_uint32_t exec_page,offset;
    ppc_insn_t insn;

--- a/unstable/ppc32_exec.c
+++ b/unstable/ppc32_exec.c
@@ -93,7 +93,7 @@ void ppc32_dump_stats(cpu_ppc_t *cpu)
 static forced_inline void ppc32_exec_memop(cpu_ppc_t *cpu,int memop,
                                            m_uint32_t vaddr,u_int dst_reg)
 {     
-   fastcall ppc_memop_fn fn;
+   ppc_memop_fn fn;
     
    fn = cpu->mem_op_fn[memop];
    fn(cpu,vaddr,dst_reg);

--- a/unstable/ppc32_mem.c
+++ b/unstable/ppc32_mem.c
@@ -759,7 +759,7 @@ static void ppc405_dump_tlb(cpu_gen_t *cpu)
 /* === PPC Memory Operations ============================================= */
 
 /* LBZ: Load Byte Zero */
-fastcall void ppc32_lbz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lbz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -770,7 +770,7 @@ fastcall void ppc32_lbz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LHZ: Load Half-Word Zero */
-fastcall void ppc32_lhz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lhz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -781,7 +781,7 @@ fastcall void ppc32_lhz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LWZ: Load Word Zero */
-fastcall void ppc32_lwz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lwz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -792,7 +792,7 @@ fastcall void ppc32_lwz(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LWBR: Load Word Byte Reverse */
-fastcall void ppc32_lwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -803,7 +803,7 @@ fastcall void ppc32_lwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LHA: Load Half-Word Algebraic */
-fastcall void ppc32_lha(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lha(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -814,7 +814,7 @@ fastcall void ppc32_lha(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STB: Store Byte */
-fastcall void ppc32_stb(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_stb(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -825,7 +825,7 @@ fastcall void ppc32_stb(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STH: Store Half-Word */
-fastcall void ppc32_sth(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_sth(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -836,7 +836,7 @@ fastcall void ppc32_sth(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STW: Store Word */
-fastcall void ppc32_stw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_stw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -847,7 +847,7 @@ fastcall void ppc32_stw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STWBR: Store Word Byte Reversed */
-fastcall void ppc32_stwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_stwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -858,7 +858,7 @@ fastcall void ppc32_stwbr(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LSW: Load String Word */
-fastcall void ppc32_lsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -869,7 +869,7 @@ fastcall void ppc32_lsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STW: Store String Word */
-fastcall void ppc32_stsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_stsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -880,7 +880,7 @@ fastcall void ppc32_stsw(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* LFD: Load Floating-Point Double */
-fastcall void ppc32_lfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_lfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -891,7 +891,7 @@ fastcall void ppc32_lfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* STFD: Store Floating-Point Double */
-fastcall void ppc32_stfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
+void ppc32_stfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 {
    m_uint64_t data;
    void *haddr;
@@ -902,7 +902,7 @@ fastcall void ppc32_stfd(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int reg)
 }
 
 /* ICBI: Instruction Cache Block Invalidate */
-fastcall void ppc32_icbi(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int op)
+void ppc32_icbi(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int op)
 {
    ppc32_jit_tcb_t *tcb;
    m_uint32_t phys_page;

--- a/unstable/ppc32_mem.c
+++ b/unstable/ppc32_mem.c
@@ -479,7 +479,7 @@ static inline void *ppc32_mem_access(cpu_ppc_t *cpu,m_uint32_t vaddr,
                     (op_type),(data))
 
 /* Virtual address to physical page translation */
-static fastcall int ppc32_translate(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int cid,
+static int ppc32_translate(cpu_ppc_t *cpu,m_uint32_t vaddr,u_int cid,
                                     m_uint32_t *phys_page)
 {   
    mts32_entry_t *entry,alt_entry;

--- a/unstable/ppc32_x86_trans.c
+++ b/unstable/ppc32_x86_trans.c
@@ -628,10 +628,12 @@ static int ppc32_emit_unknown(cpu_ppc_t *cpu,ppc32_jit_tcb_t *b,
    ppc32_set_ia(&iop->ob_ptr,b->start_ia+(b->ppc_trans_pos << 2));
 
    /* Fallback to non-JIT mode */
-   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST);
    x86_mov_reg_reg(iop->ob_ptr,X86_EAX,X86_EDI,4);
    x86_mov_reg_imm(iop->ob_ptr,X86_EDX,opcode);
 
+   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST-8);
+   x86_push_reg(iop->ob_ptr,X86_EDX);
+   x86_push_reg(iop->ob_ptr,X86_EAX);
    ppc32_emit_basic_c_call(&iop->ob_ptr,ppc32_exec_single_insn_ext);
    x86_alu_reg_imm(iop->ob_ptr,X86_ADD,X86_ESP,STACK_ADJUST);
    

--- a/unstable/ppc32_x86_trans.c
+++ b/unstable/ppc32_x86_trans.c
@@ -654,8 +654,9 @@ void ppc32_emit_breakpoint(cpu_ppc_t *cpu,ppc32_jit_tcb_t *b)
 
    iop = ppc32_op_emit_insn_output(cpu,2,"breakpoint");
 
-   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST);
    x86_mov_reg_reg(iop->ob_ptr,X86_EAX,X86_EDI,4);
+   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST-4);
+   x86_push_reg(iop->ob_ptr,X86_EAX);
    ppc32_emit_c_call(b,iop,ppc32_run_breakpoint);
    x86_alu_reg_imm(iop->ob_ptr,X86_ADD,X86_ESP,STACK_ADJUST);
 

--- a/unstable/ppc32_x86_trans.c
+++ b/unstable/ppc32_x86_trans.c
@@ -417,7 +417,10 @@ static void ppc32_emit_memop(cpu_ppc_t *cpu,ppc32_jit_tcb_t *b,
    x86_mov_reg_reg(iop->ob_ptr,X86_EAX,X86_EDI,4);
 
    /* Call memory function */
-   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST);
+   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST-12);
+   x86_push_reg(iop->ob_ptr,X86_ECX);
+   x86_push_reg(iop->ob_ptr,X86_EDX);
+   x86_push_reg(iop->ob_ptr,X86_EAX);
    x86_call_membase(iop->ob_ptr,X86_EDI,MEMOP_OFFSET(op));
    x86_alu_reg_imm(iop->ob_ptr,X86_ADD,X86_ESP,STACK_ADJUST);
    
@@ -460,7 +463,10 @@ static void ppc32_emit_memop_idx(cpu_ppc_t *cpu,ppc32_jit_tcb_t *b,
    x86_mov_reg_reg(iop->ob_ptr,X86_EAX,X86_EDI,4);
 
    /* Call memory function */
-   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST);
+   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST-12);
+   x86_push_reg(iop->ob_ptr,X86_ECX);
+   x86_push_reg(iop->ob_ptr,X86_EDX);
+   x86_push_reg(iop->ob_ptr,X86_EAX);
    x86_call_membase(iop->ob_ptr,X86_EDI,MEMOP_OFFSET(op));
    x86_alu_reg_imm(iop->ob_ptr,X86_ADD,X86_ESP,STACK_ADJUST);
    
@@ -599,7 +605,10 @@ static void ppc32_emit_memop_fast(cpu_ppc_t *cpu,ppc32_jit_tcb_t *b,
    x86_mov_reg_reg(iop->ob_ptr,X86_EAX,X86_EDI,4);
 
    /* Call memory function */
-   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST);
+   x86_alu_reg_imm(iop->ob_ptr,X86_SUB,X86_ESP,STACK_ADJUST-12);
+   x86_push_reg(iop->ob_ptr,X86_ECX);
+   x86_push_reg(iop->ob_ptr,X86_EDX);
+   x86_push_reg(iop->ob_ptr,X86_EAX);
    x86_call_membase(iop->ob_ptr,X86_EDI,MEMOP_OFFSET(opcode));
    x86_alu_reg_imm(iop->ob_ptr,X86_ADD,X86_ESP,STACK_ADJUST);
    


### PR DESCRIPTION
Function calls in x86 jit code were converted to cdecl (default C calling convention) and the stack aligned to 16 bytes.

Makes the x86 jit code portable to other languages.
Decreases the performance of x86 jit code a bit.
Prevents crashes due to a miss-aligned stack in functions calls generated by the x86 jit code.

`__attribute__((force_align_arg_pointer))` was also removed since it is no longer needed.

Fixes #254