### PR TITLE
Add ppc32 jit architecture to the build system.

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -74,15 +74,27 @@ int main (void) { return 0; }
 set_cmake_required ()
 list ( INSERT CMAKE_REQUIRED_FLAGS 0 -m32 )
 check_c_source_compiles ( "${_code}" ARCH_X86 )
+set ( _code "
+#if defined(__powerpc) || defined(__powerpc__) || defined(_M_PPC) || defined(_ARCH_PPC)
+int main (void) { return 0; }
+#else
+#error cmake_FAIL
+#endif
+" )
+set_cmake_required ()
+list ( INSERT CMAKE_REQUIRED_FLAGS 0 -m32 )
+check_c_source_compiles ( "${_code}" ARCH_PPC32 )
 if ( ARCH_AMD64 )
    set ( _default "amd64" )
 elseif ( ARCH_X86 )
    set ( _default "x86" )
+elseif ( ARCH_PPC32 )
+   set ( _default "ppc32" )
 else ()
    set ( _default "nojit" )
 endif ()
-set ( DYNAMIPS_ARCH "${_default}" CACHE STRING "Target architecture (amd64;x86;nojit)" )
-set_property ( CACHE DYNAMIPS_ARCH PROPERTY STRINGS "amd64" "x86" "nojit" )
+set ( DYNAMIPS_ARCH "${_default}" CACHE STRING "Target architecture (amd64;x86;ppc32;nojit)" )
+set_property ( CACHE DYNAMIPS_ARCH PROPERTY STRINGS "amd64" "x86" "ppc32" "nojit" )
 if ( NOT DYNAMIPS_ARCH )
    set ( DYNAMIPS_ARCH "${_default}" )
 endif ()
@@ -90,11 +102,13 @@ if ( "amd64" STREQUAL "${DYNAMIPS_ARCH}" AND ARCH_AMD64 )
    list ( INSERT DYNAMIPS_FLAGS 0 -m64 )
 elseif ( "x86" STREQUAL "${DYNAMIPS_ARCH}" AND ARCH_X86 )
    list ( INSERT DYNAMIPS_FLAGS 0 -m32 )
+elseif ( "ppc32" STREQUAL "${DYNAMIPS_ARCH}" AND ARCH_PPC32 )
+   list ( INSERT DYNAMIPS_FLAGS 0 -m32 )
 elseif ( NOT "nojit" STREQUAL "${DYNAMIPS_ARCH}" )
-   print_variables ( ARCH_AMD64 ARCH_X86 DYNAMIPS_ARCH )
+   print_variables ( ARCH_AMD64 ARCH_X86 ARCH_PPC32 DYNAMIPS_ARCH )
    message ( FATAL_ERROR "cannot build target arch DYNAMIPS_ARCH=${DYNAMIPS_ARCH}" )
 endif ()
-print_variables ( ARCH_AMD64 ARCH_X86 DYNAMIPS_ARCH )
+print_variables ( ARCH_AMD64 ARCH_X86 ARCH_PPC32 DYNAMIPS_ARCH )
 
 # Compiler flags
 foreach ( _flag

--- a/common/ppc32_ppc32_trans.c
+++ b/common/ppc32_ppc32_trans.c
@@ -1,0 +1,2 @@
+/* not supported */
+#include "ppc32_nojit_trans.c"

--- a/common/ppc32_ppc32_trans.h
+++ b/common/ppc32_ppc32_trans.h
@@ -1,0 +1,2 @@
+/* not supported */
+#include "ppc32_nojit_trans.h"

--- a/stable/CMakeLists.txt
+++ b/stable/CMakeLists.txt
@@ -269,6 +269,20 @@ maybe_rename_to_dynamips ( dynamips_x86_stable )
 install_executable ( dynamips_x86_stable )
 endif ()
 
+# dynamips_ppc32_stable
+if ( "ppc32" STREQUAL "${DYNAMIPS_ARCH}" )
+add_compile_options( -Wa,-mregnames ) # allow powerpc register names
+add_executable ( dynamips_ppc32_stable
+   ${_files}
+   "${LOCAL}/mips64_ppc32_trans.c"
+   "${COMMON}/ppc32_ppc32_trans.c"
+   )
+add_dependencies ( dynamips_ppc32_stable ${_dependencies} )
+target_link_libraries ( dynamips_ppc32_stable ${DYNAMIPS_LIBRARIES} )
+maybe_rename_to_dynamips ( dynamips_ppc32_stable )
+install_executable ( dynamips_ppc32_stable )
+endif ()
+
 # dynamips_nojit_stable
 if ( "nojit" STREQUAL "${DYNAMIPS_ARCH}" )
 add_executable ( dynamips_nojit_stable

--- a/stable/mips64_ppc32_trans.c
+++ b/stable/mips64_ppc32_trans.c
@@ -1,0 +1,2 @@
+/* not supported */
+#include "mips64_nojit_trans.c"

--- a/stable/mips64_ppc32_trans.h
+++ b/stable/mips64_ppc32_trans.h
@@ -1,0 +1,2 @@
+/* not supported */
+#include "mips64_nojit_trans.h"

--- a/unstable/CMakeLists.txt
+++ b/unstable/CMakeLists.txt
@@ -224,6 +224,20 @@ maybe_rename_to_dynamips ( dynamips_x86_unstable )
 install_executable ( dynamips_x86_unstable )
 endif ()
 
+# dynamips_ppc32_unstable
+if ( "ppc32" STREQUAL "${DYNAMIPS_ARCH}" )
+add_compile_options( -Wa,-mregnames ) # allow powerpc register names
+add_executable ( dynamips_ppc32_unstable
+   ${_files}
+   "${LOCAL}/mips64_ppc32_trans.c"
+   "${COMMON}/ppc32_ppc32_trans.c"
+   )
+add_dependencies ( dynamips_ppc32_unstable ${_dependencies} )
+target_link_libraries ( dynamips_ppc32_unstable ${DYNAMIPS_LIBRARIES} -mregnames )
+maybe_rename_to_dynamips ( dynamips_ppc32_unstable )
+install_executable ( dynamips_ppc32_unstable )
+endif ()
+
 # dynamips_nojit_unstable
 if ( "nojit" STREQUAL "${DYNAMIPS_ARCH}" )
 add_executable ( dynamips_nojit_unstable


### PR DESCRIPTION
Only unstable mips64 jit is supported.
Originaly from an older unknown unstable version.
It compiles but is unusable, with "TLB exception" messages in the cpu log.