### PR TITLE
Fix resource leak in vm_create.

### DIFF
--- a/stable/vm.c
+++ b/stable/vm.c
@@ -395,7 +395,7 @@ static vm_instance_t *vm_create(char *name,int instance_id,
  err_reg_add:
    vm_close_log(vm);
  err_log:
-   free(vm->lock_file);
+   vm_release_lock(vm,TRUE);
  err_lock:
    free(vm->rommon_vars.filename);
  err_rommon:

--- a/unstable/vm.c
+++ b/unstable/vm.c
@@ -397,7 +397,7 @@ static vm_instance_t *vm_create(char *name,int instance_id,
  err_reg_add:
    vm_close_log(vm);
  err_log:
-   free(vm->lock_file);
+   vm_release_lock(vm,TRUE);
  err_lock:
    free(vm->rommon_vars.filename);
  err_rommon:


### PR DESCRIPTION
`vm->lock_fd` was not being released.

Detected by coverity.