### PR TITLE
Fix resource leak in disk_create.

### DIFF
--- a/common/dev_pcmcia_disk.c
+++ b/common/dev_pcmcia_disk.c
@@ -295,6 +295,8 @@ static int disk_create(struct pcmcia_disk_data *d)
    else {
       /* new disk */
       if (disk_format(d)) {
+         close(d->fd);
+         d->fd = -1;
          return(-1);
       }
    }


### PR DESCRIPTION
`d->fd` was not closed when disk_format fails.

Detected by coverity as a resource leak in dev_pcmcia_disk_init.