### PR TITLE
Only run coverity_scan in the GNS3 repository.

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -16,6 +16,9 @@ env:
 
 jobs:
   coverity_scan:
+    # only run in the GNS repository
+    # based on https://stackoverflow.com/a/63822135
+    if: github.repository_owner == 'GNS3'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
My fork was getting polluted with coverity scan failures.
This should solve it for me and others.