### PR TITLE
Fix 2 memory leak bugs

### DIFF
--- a/common/dev_c3745.c
+++ b/common/dev_c3745.c
@@ -456,6 +456,7 @@ static int c3745_init_platform(c3745_t *router)
    /* Initialize the virtual MIPS processor */
    if (!(gen = cpu_create(vm,CPU_TYPE_MIPS64,0))) {
       vm_error(vm,"unable to create CPU!\n");
+      free(vm->cpu_group);
       return(-1);
    }
 

--- a/common/dev_c6msfc1.c
+++ b/common/dev_c6msfc1.c
@@ -468,6 +468,7 @@ static int c6msfc1_init_platform(c6msfc1_t *router)
    /* Initialize the virtual MIPS processor */
    if (!(gen0 = cpu_create(vm,CPU_TYPE_MIPS64,0))) {
       vm_error(vm,"unable to create CPU0!\n");
+      free(vm->cpu_group);
       return(-1);
    }
 


### PR DESCRIPTION
The function `cpu_group_create` will create a `group` object.
```c
cpu_group_t *cpu_group_create(char *name)
{
   cpu_group_t *group;

   if (!(group = malloc(sizeof(*group))))        // memory allocated here
      return NULL;

   group->name = name;
   group->cpu_list = NULL;
   return group;
}
``` 
However, in caller functions, when `cpu_create` fails, the memory object is not freed before caller functions returns.
```c
   /* Create a CPU group */
   vm->cpu_group = cpu_group_create("System CPU");

   /* Initialize the virtual MIPS processor */
   if (!(gen0 = cpu_create(vm,CPU_TYPE_MIPS64,0))) {
      vm_error(vm,"unable to create CPU0!\n");
      return(-1);          // memory leak here
   }
``` 