### PR TITLE
Release resources in error handling branches.

### DIFF
--- a/common/atm.c
+++ b/common/atm.c
@@ -697,6 +697,7 @@ int atmsw_start(char *filename)
 
    if (atmsw_read_cfg_file(t,filename) == -1) {
       fprintf(stderr,"ATMSW: unable to parse configuration file.\n");
+      atmsw_release("default");
       return(-1);
    }
 

--- a/common/atm_bridge.c
+++ b/common/atm_bridge.c
@@ -365,6 +365,7 @@ int atm_bridge_start(char *filename)
 
    if (atm_bridge_read_cfg_file(t,filename) == -1) {
       fprintf(stderr,"ATM Bridge: unable to parse configuration file.\n");
+      atm_bridge_release("default");
       return(-1);
    }
 

--- a/common/eth_switch.c
+++ b/common/eth_switch.c
@@ -945,6 +945,7 @@ int ethsw_start(char *filename)
 
    if (ethsw_read_cfg_file(t,filename) == -1) {
       fprintf(stderr,"ETHSW: unable to parse configuration file.\n");
+      ethsw_release("default");
       return(-1);
    }
 

--- a/common/frame_relay.c
+++ b/common/frame_relay.c
@@ -625,6 +625,7 @@ int frsw_start(char *filename)
 
    if (frsw_read_cfg_file(t,filename) == -1) {
       fprintf(stderr,"FRSW: unable to parse configuration file.\n");
+      frsw_release("default");
       return(-1);
    }
    

--- a/common/net_io_bridge.c
+++ b/common/net_io_bridge.c
@@ -369,6 +369,7 @@ int netio_bridge_start(char *filename)
 
    if (netio_bridge_read_cfg_file(t,filename) == -1) {
       fprintf(stderr,"NETIO_BRIDGE: unable to parse configuration file.\n");
+      netio_bridge_release("default");
       return(-1);
    }
    


### PR DESCRIPTION
In functions `netio_bridge_start` and `atm_bridge_start`, the bridge objects are not released before these functions return at error handling branches.

Here are the original functions:
```c
int netio_bridge_start(char *filename)
{
   netio_bridge_t *t;

   if (!(t = netio_bridge_create("default"))) {        // object created here
      fprintf(stderr,"NETIO_BRIDGE: unable to create virtual fabric table.\n");
      return(-1);
   }

   if (netio_bridge_read_cfg_file(t,filename) == -1) {
      fprintf(stderr,"NETIO_BRIDGE: unable to parse configuration file.\n");
      return(-1);           // not freed when function returns.
   }

   netio_bridge_release("default");
   return(0);
}
``` 

```c
int atm_bridge_start(char *filename)
{
   atm_bridge_t *t;

   if (!(t = atm_bridge_create("default"))) {            // object created here
      fprintf(stderr,"ATM Bridge: unable to create virtual fabric table.\n");
      return(-1);
   }

   if (atm_bridge_read_cfg_file(t,filename) == -1) {
      fprintf(stderr,"ATM Bridge: unable to parse configuration file.\n");
      return(-1);                // not freed when function returns.
   }

   atm_bridge_release("default");
   return(0);
}
``` 