### PR TITLE
common/insn_lookup.c : cbm_get_eqclass : dynamips crashs with this me…

### DIFF
--- a/common/insn_lookup.c
+++ b/common/insn_lookup.c
@@ -151,8 +151,10 @@ static rfc_eqclass_t *cbm_get_eqclass(rfc_array_t *rfct,cbm_array_t *cbm)
 
       /* Insert it in hash table */
       if (hash_table_insert(rfct->cbm_hash,bmp,eqcl) == -1)
+      {
          free(eqcl);
          return NULL;
+      }
    }
 
    return eqcl;


### PR DESCRIPTION
Fixes the bug https://github.com/GNS3/gns3-gui/issues/3715 : 

dynamips crashs with this error message : 
`dynamips: /home/user/dynamips/common/insn_lookup.c:259: rfc_phase_0: Assertion 'eqcl' failed.`