### PR TITLE
Add a boundary check before the integer addition

### DIFF
--- a/stable/hv_vm.c
+++ b/stable/hv_vm.c
@@ -741,7 +741,11 @@ static int cmd_push_config(hypervisor_conn_t *conn,int argc,char *argv[])
     * Convert base64 input to standard text. base64 uses 4 bytes for each group of 3 bytes.
     */
    if (strcmp(argv[1],"(keep)") != 0) {
-      startup_len = (strlen(argv[1]) + 3) / 4 * 3;
+      size_t len = strlen(argv[1]);
+      if (len + 3 < len) {
+         goto err_alloc_base64;
+      }
+      startup_len = (len + 3) / 4 * 3;
       if (!(startup_config = malloc(1 + startup_len)))
          goto err_alloc_base64;
 
@@ -752,7 +756,11 @@ static int cmd_push_config(hypervisor_conn_t *conn,int argc,char *argv[])
    }
 
    if (argc > 2 && strcmp(argv[2],"(keep)") != 0) {
-      private_len = (strlen(argv[2]) + 3) / 4 * 3;
+      size_t len = strlen(argv[2]);
+      if (len + 3 < len) {
+         goto err_alloc_base64;
+      }
+      private_len = (len + 3) / 4 * 3;
       if (!(private_config = malloc(1 + private_len)))
          goto err_alloc_base64;
 


### PR DESCRIPTION
In the function `cmd_push_config`, the decoded buffer size is computed via
```c
startup_len = (strlen(argv[1]) + 3) / 4 * 3;

private_len = (strlen(argv[2]) + 3) / 4 * 3;
``` 
Here the argv[1] and argv[2] strings originate directly from client commands. A malicious client could send an extremely large or crafted string whose length approaches SIZE_MAX. When strlen(argv[1]) or strlen(argv[2]) are close to SIZE_MAX, the addition len + 3 can wrap around and produce a much smaller value. This leads to an undersized `malloc(1 + startup_len)` allocation.

Thus, we add an explicit boundary check before performing the addition.
