### PR TITLE
Prevent negative values from external argv input

### DIFF
--- a/stable/hv_vm.c
+++ b/stable/hv_vm.c
@@ -1028,7 +1028,7 @@ static int cmd_slot_add_binding(hypervisor_conn_t *conn,int argc,char *argv[])
    if (!(vm = hypervisor_find_object(conn,argv[0],OBJ_TYPE_VM)))
       return(-1);
 
-   slot = atoi(argv[1]);
+   slot = atoi(argv[1]) < 0 ? 0 : atoi(argv[1]);
    port = atoi(argv[2]);
 
    if (vm_slot_add_binding(vm,argv[3],slot,port) == -1) {

--- a/unstable/hv_vm.c
+++ b/unstable/hv_vm.c
@@ -1041,7 +1041,7 @@ static int cmd_slot_add_binding(hypervisor_conn_t *conn,int argc,char *argv[])
    if (!(vm = hypervisor_find_object(conn,argv[0],OBJ_TYPE_VM)))
       return(-1);
 
-   slot = atoi(argv[1]);
+   slot = atoi(argv[1]) < 0 ? 0 : atoi(argv[1]);
    port = atoi(argv[2]);
 
    if (vm_slot_add_binding(vm,argv[3],slot,port) == -1) {


### PR DESCRIPTION
In function `cmd_slot_add_binding`, `argv` is obtained from external input. If the user provides a negative number string in `argv[1]` (e.g., "-1"), `atoi(argv[1])` returns a negative integer. Assigning this negative value to the unsigned integer variable `slot` causes an integer underflow, resulting in a large value. This large value is later used as an index in function `vm_slot_add_binding`, leading to an out-of-bounds access:

```c
card = vm->slots[slot_id];
```