### PR TITLE
Fix potential memory leak

### DIFF
--- a/common/dev_c6msfc1.c
+++ b/common/dev_c6msfc1.c
@@ -533,8 +533,12 @@ static int c6msfc1_init_platform(c6msfc1_t *router)
    dev_bswap_init(vm,"mem_bswap",C6MSFC1_BSWAP_ADDR,1024*1048576,0x00000000ULL);
 
    /* PCI IO space */
-   if (!(vm->pci_io_space = pci_io_data_init(vm,C6MSFC1_PCI_IO_ADDR)))
-      goto err;
+   
+   if (!vm->pci_io_space) {
+      vm->pci_io_space = pci_io_data_init(vm, C6MSFC1_PCI_IO_ADDR);
+      if (!vm->pci_io_space)
+         goto err;
+   }
 
    /* Initialize the Port Adapters */
    if (c6msfc1_init_platform_pa(router) == -1)

--- a/stable/cpu.c
+++ b/stable/cpu.c
@@ -235,6 +235,10 @@ cpu_gen_t *cpu_create(vm_instance_t *vm,u_int type,u_int id)
    /* create the CPU thread execution */
    if (pthread_create(&cpu->cpu_thread,NULL,cpu_run_fn,cpu) != 0) {
       fprintf(stderr,"cpu_create: unable to create thread for CPU%u\n",id);
+      if (cpu->exec_page_array){
+         free(cpu->exec_page_array);
+         cpu->exec_page_array = NULL;
+      }
       free(cpu);
       return NULL;
    }


### PR DESCRIPTION
Hi,

I fixed some memory leaks in the functions `cpu_create` and `c6msfc1_init_platform`.

1. In `c6msfc1_init_platform`, the function `c6msfc1_init_hw` is called, which in turn calls `pci_io_data_init` and allocates memory at `vm->pci_io_space`. 
Later in `c6msfc1_init_platform`, `pci_io_data_init` is called again, overwriting `vm->pci_io_space` and causing a potential memory leak. Fixed by add a check before the second allocation.

3. In `cpu_create`, if `pthread_create` fails, the memory allocated by `mips64_jit_init` and `ppc32_jit_init` is not freed.
